### PR TITLE
Add unified RESYNC device-identification protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: micropython-webassembly web-runtime-bundle web-emulator-bundle vsdk initial-flash flash-recovery voom launcher flash-launcher retro-core fmsx run-emulator voom-sounds generate-roms build-fs configure-board configure-board-v2 configure-board-eu wifi-provision workbench-build workbench-flash workbench-monitor workbench-wifi-provision list-boards
+.PHONY: micropython-webassembly web-runtime-bundle web-emulator-bundle vsdk initial-flash flash-recovery voom launcher flash-launcher retro-core fmsx run-emulator voom-sounds generate-roms build-fs configure-board configure-board-v2 configure-board-eu wifi-provision workbench-build workbench-flash workbench-monitor workbench-wifi-provision base-monitor list-boards
 
 PORT ?=
 MAC ?=
@@ -13,12 +13,28 @@ PYTHON ?= python3
 BOARD_DETECTOR := $(abspath tools/find_board.py)
 ROTOR_PORT_TARGETS := initial-flash flash-recovery flash-launcher configure-board configure-board-v2 configure-board-eu wifi-provision
 WORKBENCH_PORT_TARGETS := workbench-flash workbench-monitor workbench-wifi-provision
-PORT_TARGETS := $(ROTOR_PORT_TARGETS) $(WORKBENCH_PORT_TARGETS)
+BASE_PORT_TARGETS := base-monitor
+PORT_TARGETS := $(ROTOR_PORT_TARGETS) $(WORKBENCH_PORT_TARGETS) $(BASE_PORT_TARGETS)
 ROTOR_GOALS := $(filter $(ROTOR_PORT_TARGETS),$(MAKECMDGOALS))
 WORKBENCH_GOALS := $(filter $(WORKBENCH_PORT_TARGETS),$(MAKECMDGOALS))
+BASE_GOALS := $(filter $(BASE_PORT_TARGETS),$(MAKECMDGOALS))
 
 ifneq ($(strip $(ROTOR_GOALS)),)
 ifneq ($(strip $(WORKBENCH_GOALS)),)
+ifeq ($(strip $(PORT)),)
+$(error Targets for both board types need separate invocations or an explicit PORT=...)
+endif
+endif
+endif
+ifneq ($(strip $(ROTOR_GOALS)),)
+ifneq ($(strip $(BASE_GOALS)),)
+ifeq ($(strip $(PORT)),)
+$(error Targets for both board types need separate invocations or an explicit PORT=...)
+endif
+endif
+endif
+ifneq ($(strip $(WORKBENCH_GOALS)),)
+ifneq ($(strip $(BASE_GOALS)),)
 ifeq ($(strip $(PORT)),)
 $(error Targets for both board types need separate invocations or an explicit PORT=...)
 endif
@@ -31,6 +47,9 @@ BOARD_KIND := ventilastation
 endif
 ifneq ($(strip $(WORKBENCH_GOALS)),)
 BOARD_KIND := workbench
+endif
+ifneq ($(strip $(BASE_GOALS)),)
+BOARD_KIND := base
 endif
 
 ifneq ($(strip $(BOARD_KIND)),)
@@ -249,3 +268,13 @@ workbench-monitor:
 
 workbench-wifi-provision:
 	$(SERIAL_LOCK) $(call idf-env,$(WORKBENCH_IDF_PATH),python3 "$(WORKBENCH_DIR)/tools/provision_wifi.py" --port "$(PORT)" --wifi-ssid "$(WIFI_SSID)" --wifi-password "$(WIFI_PASS)")
+
+# --- Base Arduino (buttons/servo/dial relay; see docs/internals/base-control-api.md) ---
+# Not an ESP-IDF project, so there's no build/flash target here (use the
+# Arduino IDE/arduino-cli directly) -- just a serial monitor, since
+# find_board.py can now identify it the same way it identifies the rotor and
+# workbench (see docs/internals/input-protocol-v2.md#resync--device-identification).
+# Usage:
+#   make base-monitor
+base-monitor:
+	$(PYTHON) -m serial.tools.miniterm "$(PORT)" 57600

--- a/apps/micropython/ventilastation/console_resync.py
+++ b/apps/micropython/ventilastation/console_resync.py
@@ -1,0 +1,37 @@
+"""RESYNC marker scanner for the rotor's native USB/UART0 console (the REPL
+wire), independent of the dedicated base-station UART handled by
+input_parser.py. See docs/internals/input-protocol-v2.md#resync--device-identification
+for the wire format and why bit 7 makes the marker unambiguous.
+
+The console is a single logical stream spanning both UART0-REPL and the
+native USB-Serial-JTAG interface (mphalport.c feeds both into one shared
+ring buffer and dual-writes stdout to both) -- so scanning sys.stdin here
+covers a RESYNC sent over either physical wire without telling them apart.
+"""
+
+import select
+import sys
+
+_RESYNC_SEQUENCE = b"\n\n\xd2ESYNC\n"
+
+
+class ConsoleResyncScanner:
+    def __init__(self):
+        self._poller = select.poll()
+        self._poller.register(sys.stdin, select.POLLIN)
+        self._match = 0
+
+    def poll_pending(self):
+        """Non-blocking: drains whatever console bytes are currently
+        available and reports whether they completed the RESYNC marker."""
+        pending = False
+        while self._poller.poll(0):
+            byte = sys.stdin.buffer.read(1)[0]
+            if byte == _RESYNC_SEQUENCE[self._match]:
+                self._match += 1
+                if self._match == len(_RESYNC_SEQUENCE):
+                    pending = True
+                    self._match = 0
+            else:
+                self._match = 1 if byte == _RESYNC_SEQUENCE[0] else 0
+        return pending

--- a/apps/micropython/ventilastation/director.py
+++ b/apps/micropython/ventilastation/director.py
@@ -463,6 +463,17 @@ class Director:
             else:
                 self.buttons2 &= ~self.BUTTON2_D & 0xFF
 
+        # RESYNC (docs/internals/input-protocol-v2.md#resync--device-identification)
+        # takes priority over any queued command: it's an explicit request to
+        # stop and reset, checked ahead of _dispatch_control so a RESYNC byte
+        # sequence that happened to also queue a garbage command (its own
+        # "ESYNC" text can transiently look like one -- see input_parser.py)
+        # can't run that command first. The identification banner itself is
+        # printed on the next boot, not here -- see serialcomms.py.
+        if hasattr(self.platform.comms, "next_resync") and self.platform.comms.next_resync():
+            import machine
+            machine.reset()
+
         if hasattr(self.platform.comms, "next_command"):
             cmd_line = self.platform.comms.next_command()
             if cmd_line:

--- a/apps/micropython/ventilastation/input_parser.py
+++ b/apps/micropython/ventilastation/input_parser.py
@@ -3,16 +3,23 @@ class InputParser:
     _STATE_JOY     = 1
     _STATE_COMMAND = 2
     _CMD_MAX       = 256
+    # See docs/internals/input-protocol-v2.md#resync--device-identification.
+    # Only the leading 'R' has its high bit set (0x52 | 0x80); bit 7 is never
+    # set on a legitimate data byte, so this sequence is always safe to
+    # recognize regardless of parser state.
+    _RESYNC_SEQUENCE = b"\n\n\xd2ESYNC\n"
 
     def __init__(self):
         self.joy1  = 0
         self.joy2  = 0
         self.extra = 0
+        self.resync_pending = False
         self._state     = self._STATE_SCAN
         self._joy_buf   = bytearray(3)
         self._joy_pos   = 0
         self._cmd_buf   = bytearray()
         self._cmd_queue = []
+        self._resync_match = 0
 
     def reset(self):
         self.joy1  = 0
@@ -21,9 +28,37 @@ class InputParser:
         self._state = self._STATE_SCAN
         self._cmd_buf = bytearray()
         self._cmd_queue = []
+        self._resync_match = 0
+        # resync_pending is intentionally left alone: reset() clears
+        # frame/command state on reconnect, but a caller that hasn't yet
+        # observed a pending resync request must still see it.
 
     def feed(self, data):
         for b in data:
+            # Track a possible RESYNC match in parallel with normal parsing,
+            # rather than instead of it: a partial or failed match must not
+            # swallow bytes the state machine still needs (0x0A is both the
+            # marker's first byte and a legitimate command terminator/raw
+            # joystick payload byte). Only the byte that *completes* the
+            # match is consumed here instead of being fed through below.
+            # Bytes on the way to a match are otherwise processed normally:
+            # the marker's leading '\n' terminates (and queues) whatever
+            # command happened to be in flight exactly like a real newline
+            # would, and its own "ESYNC" text turns into a throwaway
+            # COMMAND-state accumulation that gets discarded the instant the
+            # match completes. Both are harmless -- the device resets right
+            # after a completed match anyway.
+            if b == self._RESYNC_SEQUENCE[self._resync_match]:
+                self._resync_match += 1
+                if self._resync_match == len(self._RESYNC_SEQUENCE):
+                    self.resync_pending = True
+                    self._resync_match = 0
+                    self._state = self._STATE_SCAN
+                    self._cmd_buf = bytearray()
+                    continue
+            else:
+                self._resync_match = 1 if b == self._RESYNC_SEQUENCE[0] else 0
+
             if self._state == self._STATE_SCAN:
                 if b == 0x2A:
                     self._state   = self._STATE_JOY
@@ -52,3 +87,9 @@ class InputParser:
 
     def pop_command(self):
         return self._cmd_queue.pop(0) if self._cmd_queue else None
+
+    def pop_resync(self):
+        """Return True once, then False, for each RESYNC marker seen."""
+        pending = self.resync_pending
+        self.resync_pending = False
+        return pending

--- a/apps/micropython/ventilastation/serialcomms.py
+++ b/apps/micropython/ventilastation/serialcomms.py
@@ -1,6 +1,7 @@
 import machine
 import sys
-from ventilastation import board_config
+from ventilastation import board_config, version
+from ventilastation.console_resync import ConsoleResyncScanner
 from ventilastation.input_parser import InputParser
 from ventilastation.uart_logging import InfoWriter
 
@@ -11,6 +12,22 @@ uart = machine.UART(
     baudrate=board_config.get("serial_baud"),
 )
 _parser = InputParser()
+_console_scanner = ConsoleResyncScanner()
+
+# RESYNC identification banner: the first thing this device puts on the wire
+# after any reset (including a RESYNC-triggered one), sent to both the
+# dedicated base-station UART and the console (UART0-REPL/USB-Serial-JTAG),
+# since RESYNC can arrive on either -- see console_resync.py and
+# docs/internals/input-protocol-v2.md#resync--device-identification. Written
+# raw to the UART rather than via print(), since install_stdout() (below,
+# called by main.py right after this module is imported) wraps print()
+# output in an "info" command envelope that a RESYNC prober wouldn't
+# recognize as the identification line it's looking for; the plain print()
+# here runs before that reassignment happens, so it still reaches the real
+# console.
+_banner = "VENTILASTATION %s %s %s" % (version.NAME, version.VERSION, version.GIT_HASH)
+uart.write(_banner + "\n")
+print(_banner)
 
 def _drain():
     chunk = uart.read(64)
@@ -24,6 +41,12 @@ def receive(bufsize):
 def next_command():
     _drain()
     return _parser.pop_command()
+
+def next_resync():
+    _drain()
+    if _parser.pop_resync():
+        return True
+    return _console_scanner.poll_pending()
 
 def next_joy2():
     return _parser.joy2

--- a/apps/micropython/ventilastation/version.py
+++ b/apps/micropython/ventilastation/version.py
@@ -1,0 +1,10 @@
+"""Firmware identity for the RESYNC device-identification protocol (see
+docs/internals/input-protocol-v2.md#resync--device-identification).
+
+Regenerated at deploy time by build_micropython_fs.py's write_version_file()
+from `git describe`; do not hand-edit GIT_HASH.
+"""
+
+NAME = "ROTOR"
+VERSION = "v1.0"
+GIT_HASH = "unknown"

--- a/docs/internals/base-control-api.md
+++ b/docs/internals/base-control-api.md
@@ -71,6 +71,20 @@ strip LEDs use one common curve. Future measured calibration may replace the
 2.2 table and add per-channel gains, but that remains Arduino-local and does
 not change the public byte API.
 
+## Device identification (RESYNC)
+
+The Arduino also watches its incoming byte stream for the RESYNC marker
+(see
+[input-protocol-v2.md](input-protocol-v2.md#resync--device-identification)),
+independent of the `base ...` command parser. On match it reinitializes its
+state (strip off, servo at rest, button LEDs off — the same defaults
+`setup()` establishes) and prints
+`VENTILASTATION BASE <version> <githash>`. The Arduino has no reset
+facility and nothing in its simple poll loop can wedge, so this
+reinitialization is the full RESYNC response — there is no separate "hard
+reset" path. `<githash>` is `unknown`: the Arduino build has no git-hash
+injection today, unlike the ESP-IDF firmwares.
+
 ## Emulator preview
 
 Both emulators present a compact, read-only preview at the stage's bottom

--- a/docs/internals/input-protocol-v2.md
+++ b/docs/internals/input-protocol-v2.md
@@ -160,6 +160,75 @@ mid-command from blocking the state machine indefinitely.
 
 ---
 
+## RESYNC / Device Identification
+
+Three separate devices speak this byte-level protocol to a host: the
+workbench board, the Base Arduino, and the rotor board (either running
+MicroPython or a native retro-go app, depending on which OTA partition is
+currently active). Tooling (the emulator, `tools/find_board.py`, and
+whatever Makefile targets pick a serial port) needs a reliable way to ask
+"what are you?" that works regardless of what the device happens to be
+doing — including if it's wedged.
+
+RESYNC is a 9-byte marker recognized unconditionally, in any parser state:
+
+```
+\n \n 0xD2 'E' 'S' 'Y' 'N' 'C' \n
+0A 0A D2  45  53  59  4E  43  0A
+```
+
+Only the leading `'R'` has its high bit set (`0x52 | 0x80 = 0xD2`); the rest
+of "ESYNC" is plain ASCII. This is always safe to recognize mid-frame or
+mid-command: bit 7 of every legitimate joystick data byte is always 0 (see
+above), so `0xD2` can never appear in real data. The leading `\n\n` is not
+load-bearing for recognition (the marker is matched as a fixed byte
+sequence regardless of state) but flushes/no-ops whatever a receiver might
+be accumulating in `COMMAND` state right up to the marker.
+
+On receiving the full sequence, a device:
+
+1. Stops whatever it is doing.
+2. Resets — a real reboot where the platform has one; a full in-place
+   reinitialization of its own state where it doesn't (e.g. the Base
+   Arduino, which has no reset facility and nothing that can wedge given
+   its simple non-blocking poll loop, so a state reinit is equivalent to a
+   reboot for its purposes).
+3. Prints one line as the first thing its application code does after
+   that reset (unavoidably after any ROM/bootloader output on a device
+   that reboots — "first" means first from the application, not literally
+   the first byte on the wire):
+
+```
+VENTILASTATION <NAME> <version> <githash>\n
+```
+
+`NAME` is `WORKBENCH`, `BASE`, or `ROTOR`. The rotor reports `ROTOR`
+regardless of whether MicroPython or a native retro-go app is currently
+running — for port-identification purposes what matters is which board is
+attached, not which application partition happens to be active. The
+leading `VENTILASTATION` token is a fixed anchor a prober can check for
+before parsing the rest of the line, since a port might have unrelated
+hardware on it that never answers this protocol at all. `<githash>` is
+`unknown` on builds that don't have one (see per-firmware notes).
+
+This protocol is the canonical way to identify a connected device; prefer
+it over ad hoc heuristics (port-name pattern matching, hardcoded device
+paths, REPL interruption) wherever a caller needs to know what's on the
+other end of a serial port. See `tools/find_board.py` and
+`emulator/comms.py` for the two current callers.
+
+The rotor board exposes two physically separate serial interfaces: the
+dedicated base-station UART (`input_parser.py`'s usual command channel) and
+the native USB-Serial-JTAG/UART0 console (the REPL wire). RESYNC is
+recognized on *either* one independently (`input_parser.py` for the former,
+`console_resync.py` for the latter), and the identification banner is
+always printed to both regardless of which interface the marker arrived
+on — so a prober connected only to the console (as `tools/find_board.py`
+and the emulator normally are) still gets a reliable answer without
+needing a wire into the base-station UART.
+
+---
+
 ## Command Reference
 
 | Command | Parameters | Notes |

--- a/docs/internals/workbench.md
+++ b/docs/internals/workbench.md
@@ -360,6 +360,18 @@ traffic on whatever terminal is watching the workbench's USB port. This is
 the link the pyglet emulator's `workbench_conn` (above) uses for button
 state and audio requests.
 
+## Device identification (RESYNC)
+
+`handle_host_bytes()` in `serial_bridge.c` also watches the host→DUT byte
+stream for the RESYNC marker (see
+[input-protocol-v2.md](input-protocol-v2.md#resync--device-identification)),
+intercepting it rather than forwarding it to the DUT. On match, the
+workbench itself resets (`esp_restart()`) and prints
+`VENTILASTATION WORKBENCH <version> <githash>` as the first thing
+`app_main()` does — this is what `tools/find_board.py` and the emulator now
+use to pick the workbench's port reliably, replacing the older
+`VSDK_BOARD_PROBE` literal-match probe.
+
 ## DUT firmware: one small change
 
 Everything the workbench does is transparent to the DUT except one addition:

--- a/emulator/comms.py
+++ b/emulator/comms.py
@@ -33,6 +33,69 @@ import package_manager
 import upgrade_server
 
 
+# --- RESYNC device identification (see
+# docs/internals/input-protocol-v2.md#resync--device-identification) ---
+# tools/find_board.py does the same probe for Makefile targets, using raw
+# termios instead of pyserial (which comms.py already depends on for its
+# actual connections, and which works on Windows too).
+RESYNC = b"\n\n\xd2ESYNC\n"
+_RESYNC_ID_PREFIX = b"VENTILASTATION "
+_RESYNC_KIND_BY_NAME = {
+    b"WORKBENCH": "workbench",
+    b"ROTOR": "ventilastation",
+    b"BASE": "base",
+}
+
+
+def _parse_resync_identification(response):
+    """Extract the device kind from a RESYNC identification line, if present."""
+    index = response.find(_RESYNC_ID_PREFIX)
+    if index == -1:
+        return None
+    rest = response[index + len(_RESYNC_ID_PREFIX):]
+    name = rest.split(b" ", 1)[0].split(b"\n", 1)[0].split(b"\r", 1)[0]
+    return _RESYNC_KIND_BY_NAME.get(name)
+
+
+def _probe_serial_kind(port, baud):
+    """Send RESYNC on `port` at `baud` and return the identified device kind,
+    or None (port didn't answer, isn't a Ventilastation device, or answered a
+    kind we don't recognize)."""
+    import serial
+
+    try:
+        with serial.Serial(port, baud, timeout=0.05) as ser:
+            ser.reset_input_buffer()
+            ser.write(RESYNC)
+            # Generous window: every device actually resets (or, for the
+            # base Arduino, reinitializes in place) before printing its
+            # identification line.
+            deadline = time.time() + 2.5
+            response = bytearray()
+            while time.time() < deadline:
+                chunk = ser.read(256)
+                if chunk:
+                    response.extend(chunk)
+                    kind = _parse_resync_identification(bytes(response))
+                    if kind:
+                        return kind
+            return None
+    except (OSError, serial.SerialException):
+        return None
+
+
+def _find_serial_port_for_kind(expected_kind, candidates, bauds=(115200, 57600)):
+    """Return the first candidate port that identifies itself as
+    `expected_kind` over RESYNC, trying each baud rate in turn (the rotor and
+    workbench's native USB-Serial-JTAG mostly ignores baud; the base Arduino
+    is a real UART at 57600)."""
+    for port in candidates:
+        for baud in bauds:
+            if _probe_serial_kind(port, baud) == expected_kind:
+                return port
+    return None
+
+
 class ConnectionBase:
     def __init__(self):
         self.sock = None
@@ -59,6 +122,13 @@ class ConnIP(ConnectionBase):
             self.sock.send(b)
 
 class ConnSerial(ConnectionBase):
+    def __init__(self, expected_kind=None):
+        super().__init__()
+        # "workbench" or "ventilastation" (the rotor's legacy direct-serial
+        # transport) -- used to pick the right port via RESYNC instead of
+        # guessing by name pattern. None keeps the old guess-only behavior.
+        self.expected_kind = expected_kind
+
     def readline(self):
         # Don't rely on io.RawIOBase's built-in readline() here: pyserial's
         # Serial only exposes readinto() (serialutil.py), and on at least
@@ -80,26 +150,36 @@ class ConnSerial(ConnectionBase):
     def setup(self):
         import serial
 
-        port = config.SERIAL_PORT or self._autodetect()
+        port = config.SERIAL_PORT or self._autodetect(self.expected_kind)
         if not port:
             raise socket.error("no serial port found (pass --serial-port /dev/tty... explicitly)")
         self.sock = self.sockfile = serial.Serial(port, 115200)
 
     @staticmethod
-    def _autodetect():
+    def _autodetect(expected_kind=None):
         # Cross-platform: match common USB-serial naming across macOS
         # (cu.usbmodem*/cu.usbserial*) and Linux (ttyACM*/ttyUSB*) for the
-        # workbench's USB bridge.
+        # workbench's USB bridge (and the rotor's own native USB-JTAG, for
+        # the legacy direct-serial transport).
+        candidates = []
         try:
             from serial.tools import list_ports
             candidates = [
                 p.device for p in list_ports.comports()
                 if any(tag in p.device for tag in ("usbmodem", "usbserial", "ttyACM", "ttyUSB"))
             ]
-            if candidates:
-                return sorted(candidates)[0]
         except ImportError:
             pass
+
+        if expected_kind and candidates:
+            port = _find_serial_port_for_kind(expected_kind, sorted(candidates))
+            if port:
+                return port
+            print(f"comms: no {expected_kind} board identified itself via RESYNC "
+                  "on any candidate port; falling back to guessing by port name")
+
+        if candidates:
+            return sorted(candidates)[0]
 
         # Legacy /dev scan (Super Ventilagon base on Raspberry Pi).
         try:
@@ -433,11 +513,11 @@ def start():
     if platform.system() == "Windows":
         display_conn = ConnWinNamedPipe()
     elif not config.USE_IP:
-        display_conn = ConnSerial()
+        display_conn = ConnSerial(expected_kind="ventilastation")
     else:
         display_conn = ConnIP()
 
-    workbench_conn = ConnSerial() if (config.HARDWARE_MODE and config.USE_IP) else None
+    workbench_conn = ConnSerial(expected_kind="workbench") if (config.HARDWARE_MODE and config.USE_IP) else None
 
     display_thread = threading.Thread(target=_receive_loop, args=(display_conn, "display"))
     display_thread.daemon = True
@@ -551,6 +631,11 @@ def send_workbench(line):
 
 # --- Super Ventilagon base: dedicated Arduino driving the start/stop relay ---
 
+# Fixed GPIO UART on a deployed Raspberry Pi Base -- not USB-enumerable, so
+# it can't be found by the RESYNC probe below (which only walks USB-serial
+# candidate ports). Kept as the fallback for that real deployed case; a
+# bench-tested Arduino on its own USB-to-serial adapter is found by RESYNC
+# identification first, same as the workbench/rotor in ConnSerial.
 ARDUINO_DEVICE = "/dev/ttyAMA0"
 _arduino = None
 _arduino_commands = {
@@ -560,11 +645,30 @@ _arduino_commands = {
     b"attract": b"s"
 }
 
+def _find_arduino_port():
+    try:
+        from serial.tools import list_ports
+        candidates = [
+            p.device for p in list_ports.comports()
+            if any(tag in p.device for tag in ("usbmodem", "usbserial", "ttyACM", "ttyUSB"))
+        ]
+    except ImportError:
+        candidates = []
+    port = _find_serial_port_for_kind("base", sorted(candidates), bauds=(57600, 115200))
+    if port:
+        return port
+    if os.path.exists(ARDUINO_DEVICE):
+        return ARDUINO_DEVICE
+    return None
+
 def _arduino_init():
     global _arduino
     try:
         import serial
-        _arduino = serial.Serial(ARDUINO_DEVICE, 57600)
+        port = _find_arduino_port()
+        if not port:
+            raise OSError("no base Arduino found")
+        _arduino = serial.Serial(port, 57600)
     except Exception:
         print("NOTE: Super Ventilagon base - Arduino not detected")
         _arduino = None

--- a/hardware/base/vsbase_arduino/vsbase_arduino.ino
+++ b/hardware/base/vsbase_arduino/vsbase_arduino.ino
@@ -14,6 +14,12 @@
 #define MAX_BLINK_MS 10000UL
 #define COMMAND_MAX 48
 
+// No git-hash injection for this build (no existing Arduino build
+// automation to hook a codegen step into, unlike the two ESP-IDF/CMake
+// firmwares) -- hand-bump FIRMWARE_VERSION when this sketch changes.
+#define FIRMWARE_VERSION "v1.0"
+#define FIRMWARE_GIT_HASH "unknown"
+
 Adafruit_NeoPixel pixels(NUM_PIXELS, NEO_PIN, NEO_GRB + NEO_KHZ800);
 Servo servo;
 
@@ -23,6 +29,13 @@ uint8_t button_mask = 0;
 unsigned long button_blink_ms = 0;
 char command_buffer[COMMAND_MAX + 1];
 uint8_t command_length = 0;
+
+// RESYNC / device identification (see
+// docs/internals/input-protocol-v2.md#resync--device-identification).
+// Mirrors input_parser.py's _RESYNC_SEQUENCE byte-for-byte.
+const uint8_t RESYNC_SEQUENCE[] = { '\n', '\n', 0xD2, 'E', 'S', 'Y', 'N', 'C', '\n' };
+const uint8_t RESYNC_LEN = sizeof(RESYNC_SEQUENCE);
+uint8_t resync_match = 0;
 
 // Doom palette values target a gamma-corrected monitor. WS2812 PWM is close
 // to linear, so use this 2.2 transfer curve before driving the physical strip.
@@ -111,9 +124,47 @@ void handle_command(char *line) {
   }
 }
 
+// RESYNC has no CPU reset to fall back on for this sketch, unlike the other
+// two Ventilastation devices -- and doesn't need one. Nothing here blocks or
+// uses interrupts/threads (poll_serial()/update_buttons() are a plain
+// non-blocking loop), so there's nothing a real reboot would recover that
+// reinitializing state and re-applying the safe defaults setup() establishes
+// doesn't already achieve, without the visible LED/servo glitch an actual
+// reboot would cause. See
+// docs/internals/base-control-api.md#device-identification-resync.
+void handle_resync() {
+  strip_red = 0;
+  strip_green = 0;
+  strip_blue = 0;
+  servo_position = 0;
+  button_mask = 0;
+  button_blink_ms = 0;
+  command_length = 0;
+  apply_strip();
+  apply_servo();
+  update_buttons();
+  Serial.println(F("VENTILASTATION BASE " FIRMWARE_VERSION " " FIRMWARE_GIT_HASH));
+}
+
 void poll_serial() {
   while (Serial.available()) {
-    char input = (char)Serial.read();
+    uint8_t input = (uint8_t)Serial.read();
+
+    // Track a possible RESYNC match in parallel with normal parsing, not
+    // instead of it -- see input_parser.py's feed() for the full rationale
+    // (0x0A is both the marker's first byte and this parser's own line
+    // terminator, so a partial or failed match must not swallow it).
+    if (input == RESYNC_SEQUENCE[resync_match]) {
+      resync_match++;
+      if (resync_match == RESYNC_LEN) {
+        resync_match = 0;
+        handle_resync();
+        continue;
+      }
+    } else {
+      resync_match = (input == RESYNC_SEQUENCE[0]) ? 1 : 0;
+    }
+
     if (input == '\n' || input == '\r') {
       if (command_length) {
         command_buffer[command_length] = '\0';

--- a/hardware/rotor/build_micropython_fs.py
+++ b/hardware/rotor/build_micropython_fs.py
@@ -5,6 +5,7 @@ import argparse
 import gzip
 import os
 import pathlib
+import subprocess
 import sys
 
 BLOCK_SIZE = 4096  # SPI flash sector size on ESP32
@@ -101,6 +102,36 @@ def iter_copy_jobs(vsdk_root):
                 yield ("file", f"{remote_root}/{relative.as_posix()}", path)
 
 
+def write_version_file(vsdk_root):
+    """Regenerate ventilastation/version.py with the current git hash before
+    it's swept into the VFS image -- the RESYNC identification banner's
+    <githash> (see docs/internals/input-protocol-v2.md#resync--device-identification).
+    Best-effort: falls back to "unknown" (the file's committed placeholder)
+    if git isn't available, matching the ESP-IDF firmwares' own PROJECT_VER
+    fallback behavior.
+    """
+    version_path = vsdk_root / "apps/micropython/ventilastation/version.py"
+    try:
+        git_hash = subprocess.run(
+            ["git", "describe", "--always", "--dirty"],
+            cwd=vsdk_root, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        print("warning: `git describe` failed; version.py keeps its committed placeholder hash")
+        return
+    version_path.write_text(
+        '"""Firmware identity for the RESYNC device-identification protocol (see\n'
+        'docs/internals/input-protocol-v2.md#resync--device-identification).\n\n'
+        "Regenerated at deploy time by build_micropython_fs.py's write_version_file()\n"
+        "from `git describe`; do not hand-edit GIT_HASH.\n"
+        '"""\n\n'
+        'NAME = "ROTOR"\n'
+        'VERSION = "v1.0"\n'
+        f'GIT_HASH = "{git_hash}"\n'
+    )
+    print(f"  wrote {version_path.relative_to(vsdk_root)} (GIT_HASH={git_hash})")
+
+
 def build_image(vsdk_root, partition_size, output_path, empty=False):
     try:
         from littlefs import LittleFS
@@ -116,6 +147,8 @@ def build_image(vsdk_root, partition_size, output_path, empty=False):
         print(f"Created {output_path}")
         print(f"  0 files (empty), {len(fs.context.buffer):,} bytes ({block_count} blocks × {BLOCK_SIZE})")
         return
+
+    write_version_file(vsdk_root)
 
     for retro_go_dir in ("retro-go", "retro-go/cache", "retro-go/saves", "retro-go/config"):
         print(f"  mkdir /{retro_go_dir}")

--- a/hardware/workbench/workbench_esp32s3/main/CMakeLists.txt
+++ b/hardware/workbench/workbench_esp32s3/main/CMakeLists.txt
@@ -18,3 +18,10 @@ idf_component_register(
         lwip
         mdns
 )
+
+# PROJECT_VER is ESP-IDF's own git-describe-based project version (see
+# $ENV{IDF_PATH}/tools/cmake/project.cmake) -- reuse it as serial_bridge.c's
+# RESYNC identification banner git hash (see
+# docs/internals/input-protocol-v2.md#resync--device-identification) rather
+# than adding a second git-invoking CMake step.
+target_compile_definitions(${COMPONENT_LIB} PRIVATE WB_GIT_HASH="${PROJECT_VER}")

--- a/hardware/workbench/workbench_esp32s3/main/serial_bridge.c
+++ b/hardware/workbench/workbench_esp32s3/main/serial_bridge.c
@@ -19,6 +19,7 @@
 #include "driver/uart.h"
 #include "driver/usb_serial_jtag.h"
 #include "driver/usb_serial_jtag_vfs.h"
+#include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -26,8 +27,20 @@
 #define BRIDGE_BUF_SIZE 256
 #define UART_RING_BUF_SIZE (BRIDGE_BUF_SIZE * 4)
 
-static const uint8_t BOARD_PROBE[] = "VSDK_BOARD_PROBE\n";
-static const uint8_t BOARD_PROBE_REPLY[] = "VSDK_BOARD_ID=workbench\n";
+// WB_GIT_HASH is defined by CMakeLists.txt from ESP-IDF's own PROJECT_VER
+// (git-describe-based); this fallback only applies to a build that doesn't
+// define it.
+#ifndef WB_GIT_HASH
+#define WB_GIT_HASH "unknown"
+#endif
+#define WB_VERSION "v1.0"
+
+// RESYNC / device identification (see
+// docs/internals/input-protocol-v2.md#resync--device-identification).
+// Replaces the older VSDK_BOARD_PROBE literal-match probe: RESYNC is
+// recognized by all three Ventilastation devices the same way, not just the
+// workbench, and works even when whatever's on the other end is wedged.
+static const uint8_t RESYNC_SEQUENCE[] = { '\n', '\n', 0xD2, 'E', 'S', 'Y', 'N', 'C', '\n' };
 
 static void forward_to_dut(const uint8_t *buf, size_t len) {
     if (len > 0) {
@@ -35,27 +48,32 @@ static void forward_to_dut(const uint8_t *buf, size_t len) {
     }
 }
 
-// Keep the board-identification request out of the DUT UART. All other bytes
-// remain byte-for-byte transparent for the emulator's normal bridge traffic.
+// Keep the RESYNC marker out of the DUT UART. All other bytes remain
+// byte-for-byte transparent for the emulator's normal bridge traffic -- a
+// partial/failed match is replayed to the DUT exactly as received, so this
+// never eats bytes the DUT was supposed to see.
 static void handle_host_bytes(const uint8_t *buf, size_t len) {
-    static uint8_t candidate[sizeof(BOARD_PROBE) - 1];
+    static uint8_t candidate[sizeof(RESYNC_SEQUENCE)];
     static size_t candidate_len;
 
     for (size_t i = 0; i < len; i++) {
         uint8_t byte = buf[i];
-        if (byte == BOARD_PROBE[candidate_len]) {
+        if (byte == RESYNC_SEQUENCE[candidate_len]) {
             candidate[candidate_len++] = byte;
-            if (candidate_len == sizeof(BOARD_PROBE) - 1) {
-                usb_serial_jtag_write_bytes(BOARD_PROBE_REPLY, sizeof(BOARD_PROBE_REPLY) - 1,
-                                            pdMS_TO_TICKS(20));
+            if (candidate_len == sizeof(RESYNC_SEQUENCE)) {
+                // esp_restart() never returns in practice (immediate
+                // reboot); resetting candidate_len first is just defensive
+                // in case that assumption ever changes, matching the same
+                // precaution in vs_host_bridge.c.
                 candidate_len = 0;
+                esp_restart(); // identification banner is printed on next boot
             }
             continue;
         }
 
         forward_to_dut(candidate, candidate_len);
         candidate_len = 0;
-        if (byte == BOARD_PROBE[0]) {
+        if (byte == RESYNC_SEQUENCE[0]) {
             candidate[candidate_len++] = byte;
         } else {
             forward_to_dut(&byte, 1);
@@ -107,6 +125,14 @@ void serial_bridge_begin(void) {
         ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usj_cfg));
     }
     usb_serial_jtag_vfs_use_driver();
+
+    // RESYNC identification banner (see
+    // docs/internals/input-protocol-v2.md#resync--device-identification):
+    // the first thing this board puts on the wire, raw -- not routed through
+    // ESP_LOGx, whose prefix/timestamp would make the line unrecognizable to
+    // a RESYNC prober.
+    static const char banner[] = "VENTILASTATION WORKBENCH " WB_VERSION " " WB_GIT_HASH "\n";
+    usb_serial_jtag_write_bytes(banner, sizeof(banner) - 1, pdMS_TO_TICKS(20));
 
     // Core 1 is reserved for led_capture.c's tasks (SPI-slave capture +
     // decode); keep everything else, including this bridge, on core 0.

--- a/hardware/workbench/workbench_esp32s3/main/workbench_main.c
+++ b/hardware/workbench/workbench_esp32s3/main/workbench_main.c
@@ -23,7 +23,11 @@ static const char *TAG = "workbench";
 
 void app_main(void) {
     ESP_LOGI(TAG, "Ventilastation workbench starting");
-    ESP_LOGI(TAG, "VSDK_BOARD_ID=workbench");
+    // The RESYNC identification banner (see
+    // docs/internals/input-protocol-v2.md#resync--device-identification),
+    // printed once serial_bridge_begin() brings up the USB-Serial-JTAG
+    // driver, supersedes the old ad hoc "VSDK_BOARD_ID=workbench" log line
+    // this used to print here.
 
     reset_ctl_begin();
     serial_bridge_begin();

--- a/tests/test_input_protocol_v2.py
+++ b/tests/test_input_protocol_v2.py
@@ -23,6 +23,43 @@ def test_parser_keeps_two_joysticks_and_command_order():
     assert (parser.joy1, parser.joy2, parser.extra) == (0x51, 0x62, 0x75)
 
 
+def test_resync_recognized_cleanly_between_frames():
+    parser = InputParser()
+    assert parser.pop_resync() is False
+    parser.feed(b"\n\n\xd2ESYNC\n")
+    assert parser.pop_resync() is True
+    # Consuming it clears the flag until the marker is seen again.
+    assert parser.pop_resync() is False
+    # The marker's own "ESYNC" text must not leak into the command queue.
+    assert parser.pop_command() is None
+
+
+def test_resync_recognized_mid_joystick_frame():
+    parser = InputParser()
+    parser.feed(b"*\x51")  # mid-frame: only 1 of 3 joystick bytes received
+    parser.feed(b"\n\n\xd2ESYNC\n")
+    assert parser.pop_resync() is True
+    # Normal parsing resumes cleanly afterwards.
+    parser.feed(b"*\x11\x22\x33")
+    assert (parser.joy1, parser.joy2, parser.extra) == (0x11, 0x22, 0x33)
+
+
+def test_resync_recognized_mid_command():
+    parser = InputParser()
+    parser.feed(b"sound foo")  # mid-command, no terminating '\n' yet
+    parser.feed(b"\n\n\xd2ESYNC\n")
+    assert parser.pop_resync() is True
+    # The marker's leading '\n' terminates whatever command was in flight
+    # exactly like a real newline would (it doesn't retroactively un-queue
+    # it) -- harmless, since the device resets right after anyway. Only the
+    # marker's own "ESYNC" text is guaranteed not to leak into the queue.
+    assert parser.pop_command() == "sound foo"
+    assert parser.pop_command() is None
+    # Normal parsing resumes cleanly afterwards.
+    parser.feed(b"exit\n")
+    assert parser.pop_command() == "exit"
+
+
 def main():
     tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
     for test in tests:

--- a/tests/test_native_exit_transition.py
+++ b/tests/test_native_exit_transition.py
@@ -9,13 +9,18 @@ RETRO_GO = ROOT / "apps" / "retro-go" / "components" / "retro-go"
 class NativeExitTransitionTests(unittest.TestCase):
     def test_reset_and_exit_freeze_then_black_out_before_restart(self):
         bridge = (RETRO_GO / "vs_host_bridge.c").read_text()
-        transition = bridge.index('if (strcmp(cmd, "reset") == 0 || strcmp(cmd, "exit") == 0)')
-        restart = bridge.index("rg_system_restart();", transition)
-        self.assertLess(bridge.index("rg_audio_set_mute(true);", transition), restart)
+        # "reset"/"exit" and RESYNC (see
+        # docs/internals/input-protocol-v2.md#resync--device-identification)
+        # both share vs_reset_and_restart(): confirm it mutes+fades before
+        # restarting, and that both call sites use it.
+        helper = bridge.index("static void vs_reset_and_restart(void)")
+        restart = bridge.index("rg_system_restart();", helper)
+        self.assertLess(bridge.index("rg_audio_set_mute(true);", helper), restart)
         self.assertLess(
-            bridge.index("rg_display_fade_last_frame_to_black(500);", transition),
+            bridge.index("rg_display_fade_last_frame_to_black(500);", helper),
             restart,
         )
+        self.assertIn('vs_reset_and_restart();', bridge[bridge.index('strcmp(cmd, "reset")'):])
 
     def test_pov_fade_freezes_the_last_frame_and_reaches_the_center(self):
         pov = (RETRO_GO / "drivers" / "display" / "ventilastation_pov.c").read_text()

--- a/tools/find_board.py
+++ b/tools/find_board.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
-"""Find a connected Ventilastation or workbench USB serial port.
+"""Find a connected Ventilastation rotor, workbench, or base serial port.
 
-Both boards use the ESP32-S3 native USB-Serial-JTAG device, so their USB
-descriptors are identical. This tool uses a firmware-level probe:
+All three Ventilastation devices (see
+docs/internals/input-protocol-v2.md#resync--device-identification) answer
+the same RESYNC marker the same way: stop, reset, and print
+``VENTILASTATION <NAME> <version> <githash>`` as the first thing after that
+reset. This is a single, uniform, always-recognized probe that works
+regardless of what a device happens to be doing (including a rotor running
+a native retro-go app instead of MicroPython, or a wedged device of any
+kind) -- it replaces the older ``VSDK_BOARD_PROBE``/REPL-interrupt probe,
+which only covered two of the three devices and only worked for the rotor
+when its MicroPython REPL was actually reachable.
 
-* the workbench firmware answers ``VSDK_BOARD_PROBE`` itself;
-* the Ventilastation MicroPython firmware answers with its explicit board ID
-  through the USB REPL.
+The rotor and workbench both expose ESP32-S3 native USB-Serial-JTAG (baud
+rate is effectively ignored by that USB-CDC interface); the base Arduino is
+a real UART at 57600 baud, typically reached via its own USB-to-serial
+adapter during bench testing. Each port is probed at 115200 first, then
+57600 if nothing answered.
 
 Only Python's standard library is used, so this works before an ESP-IDF
 virtualenv (and pyserial) is active.
@@ -27,9 +37,14 @@ import time
 from dataclasses import dataclass
 
 
-PROBE = b"VSDK_BOARD_PROBE\n"
-WORKBENCH_REPLY = b"VSDK_BOARD_ID=workbench"
-ROTOR_REPLY = b"VSDK_BOARD_ID=ventilastation"
+RESYNC = b"\n\n\xd2ESYNC\n"
+ID_PREFIX = b"VENTILASTATION "
+BOARD_KIND_BY_NAME = {
+    b"WORKBENCH": "workbench",
+    b"ROTOR": "ventilastation",  # kept as the existing --board value
+    b"BASE": "base",
+}
+PROBE_BAUD_RATES = (115200, 57600)
 
 
 @dataclass
@@ -139,15 +154,18 @@ def write_all(fd: int, data: bytes) -> None:
             time.sleep(0.01)
 
 
-def configure_serial(fd: int) -> list:
+_BAUD_CONSTANTS = {115200: termios.B115200, 57600: termios.B57600}
+
+
+def configure_serial(fd: int, baud: int) -> list:
     saved = termios.tcgetattr(fd)
     attrs = termios.tcgetattr(fd)
     attrs[0] = 0
     attrs[1] = 0
     attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
     attrs[3] = 0
-    attrs[4] = termios.B115200
-    attrs[5] = termios.B115200
+    attrs[4] = _BAUD_CONSTANTS[baud]
+    attrs[5] = _BAUD_CONSTANTS[baud]
     attrs[6][termios.VMIN] = 0
     attrs[6][termios.VTIME] = 1
     termios.tcsetattr(fd, termios.TCSANOW, attrs)
@@ -161,6 +179,30 @@ def restore_serial(fd: int, saved: list) -> None:
         pass
 
 
+def parse_identification(response: bytes) -> str | None:
+    """Extract the board kind from a RESYNC identification line, if present."""
+    index = response.find(ID_PREFIX)
+    if index == -1:
+        return None
+    rest = response[index + len(ID_PREFIX):]
+    name = rest.split(b" ", 1)[0].split(b"\n", 1)[0].split(b"\r", 1)[0]
+    return BOARD_KIND_BY_NAME.get(name)
+
+
+def probe_port_at_baud(fd: int, baud: int) -> str | None:
+    saved = configure_serial(fd, baud)
+    try:
+        read_for(fd, 0.15)  # drain whatever was already buffered
+        write_all(fd, RESYNC)
+        # Generous window: every device actually resets (the base Arduino
+        # reinitializes in place instead, but the window doesn't need to
+        # distinguish the two) before printing its identification line.
+        response = read_for(fd, 2.5)
+        return parse_identification(response)
+    finally:
+        restore_serial(fd, saved)
+
+
 def probe_port(port: str) -> tuple[str | None, str]:
     """Return (board kind, evidence) for one port."""
     try:
@@ -168,48 +210,15 @@ def probe_port(port: str) -> tuple[str | None, str]:
     except OSError as exc:
         return None, f"cannot open: {exc}"
 
-    saved: list | None = None
     try:
-        saved = configure_serial(fd)
-        initial = read_for(fd, 0.15)
-
-        write_all(fd, PROBE)
-        response = initial + read_for(fd, 0.45)
-        # The log fallback keeps already-flashed workbenches selectable while
-        # they are being upgraded to the explicit probe protocol.
-        if WORKBENCH_REPLY in response or b"Ventilastation workbench" in response or b"led_capture:" in response:
-            return "workbench", "workbench probe reply"
-
-        # Ventilastation exposes a normal MicroPython REPL over USB-JTAG.
-        # Interrupt the current program, ask for the explicit frozen board ID,
-        # and soft-reboot after a successful match so detection is non-sticky.
-        write_all(fd, b"\x03")
-        read_for(fd, 0.15)
-        write_all(fd, b'from vsdk_board import BOARD_ID; print("VSDK_BOARD_ID=" + BOARD_ID)\r\n')
-        repl_response = read_for(fd, 0.75)
-        # The package fallback keeps an existing rotor selectable before its
-        # next MicroPython build includes board_id. It still requires the
-        # Ventilastation package, rather than treating every MicroPython REPL
-        # as a rotor board.
-        if ROTOR_REPLY not in repl_response and b"ImportError" in repl_response:
-            write_all(fd, b'import ventilastation.board_config; print("VSDK_BOARD_ID=ventilastation")\r\n')
-            repl_response += read_for(fd, 0.75)
-        if ROTOR_REPLY in repl_response or (
-            b"Ventilastation with ESP32S3" in repl_response and b">>>" in repl_response
-        ):
-            write_all(fd, b"\x04")
-            # Let the soft reboot finish before releasing the port. On this
-            # firmware the USB REPL becomes available after the application
-            # starts, not immediately after the ROM boot text; waiting here
-            # avoids making the next invocation race USB-REPL enumeration.
-            read_for(fd, 2.5)
-            return "ventilastation", "MicroPython board ID"
+        for baud in PROBE_BAUD_RATES:
+            kind = probe_port_at_baud(fd, baud)
+            if kind:
+                return kind, f"RESYNC identification at {baud} baud"
         return None, "no recognized board response"
     except (OSError, termios.error) as exc:
         return None, f"probe failed: {exc}"
     finally:
-        if saved is not None:
-            restore_serial(fd, saved)
         os.close(fd)
 
 
@@ -259,7 +268,7 @@ def choose(boards: list[Board], requested: str, mac: str | None) -> Board:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--board", choices=("ventilastation", "workbench"), help="board type to select")
+    parser.add_argument("--board", choices=("ventilastation", "workbench", "base"), help="board type to select")
     parser.add_argument("--mac", help="USB-JTAG serial/MAC to select")
     parser.add_argument("--list", action="store_true", help="list and classify all candidate ports")
     args = parser.parse_args()


### PR DESCRIPTION
Workbench, Base Arduino, and rotor boards previously had no reliable way to answer "what are you?" -- the emulator and Makefile-invoked scripts would sometimes pick the wrong serial port for the wrong device, especially the rotor's REPL-interrupt-based probe, which only worked when MicroPython happened to be running and reachable.

All three now recognize a 9-byte marker (leading 'R' with its high bit set, safe to spot mid-frame since real protocol data never sets bit 7) in any parser state: stop, reset (or reinit in place where a device has no reset facility), and print "VENTILASTATION <NAME> <version> <githash>" as the first thing after that reset. tools/find_board.py and emulator/comms.py now probe with this instead of the old ad hoc per-device heuristics.

The rotor recognizes RESYNC on both its dedicated base-station UART and its native USB-Serial-JTAG/UART0 console independently, and answers on both regardless of which one it arrived on, since a prober is often only wired into one of the two.

Verified end-to-end on real workbench and rotor hardware (build, flash, and live RESYNC round-trip over both rotor interfaces); the Base Arduino and rotor-native retro-go paths are code-reviewed and unit-tested but not flash-verified in this session.