### PR TITLE
Speed up sprite ROM loading: length-prefixed gzip (.romz)

### DIFF
--- a/apps/micropython/main.py
+++ b/apps/micropython/main.py
@@ -115,9 +115,9 @@ def _check_install_boot():
 
 _check_install_boot()
 
-# A system OTA restores the tree's roms/menu.rom.gz, which shadows the merged
+# A system OTA restores the tree's roms/menu.romz, which shadows the merged
 # plain menu rom carrying installed packages' icons (director.load_rom prefers
-# the .gz). Re-merge the stored packages' icons when that happened; on a
+# the .romz). Re-merge the stored packages' icons when that happened; on a
 # normal boot this is just two stats.
 try:
     from ventilastation import menurom as _menurom

--- a/apps/micropython/ventilastation/director.py
+++ b/apps/micropython/ventilastation/director.py
@@ -385,27 +385,35 @@ class Director:
             stripes[filename.decode("utf-8")] = n
 
     def load_rom(self, filename):
-        # On the board, ROMs are stored gzip-compressed as "<name>.rom.gz" in the
-        # LittleFS image to save flash (see build_micropython_fs.py). If that file
-        # exists, inflate the whole ROM into RAM via the `deflate` module and parse
-        # it in memory. Otherwise fall through to loading the uncompressed
-        # "<name>.rom" (e.g. the desktop emulator reading straight from the repo).
-        gz_filename = filename + ".gz"
+        # On the board, ROMs are stored gzip-compressed as "<name>.romz" in the
+        # LittleFS image to save flash (see build_micropython_fs.py): a
+        # little-endian uint32 uncompressed size followed by the gzip data.
+        # Knowing the size upfront lets the whole ROM be inflated into one
+        # preallocated buffer via readinto() -- like the uncompressed
+        # codepath below -- instead of DeflateIO.read()'s unsized read, which
+        # reallocates and copies repeatedly as the result grows. Otherwise
+        # fall through to loading the uncompressed "<name>.rom" (e.g. the
+        # desktop emulator reading straight from the repo).
+        romz_filename = filename + "z"
         try:
-            uos.stat(gz_filename)
+            uos.stat(romz_filename)
         except OSError:
             pass
         else:
             import deflate
-            romfile = open(gz_filename, "rb")
+            romfile = open(romz_filename, "rb")
             try:
+                romlength = struct.unpack("<I", romfile.read(4))[0]
+                rombuffer = bytearray(romlength)
+                romview = memoryview(rombuffer)
                 stream = deflate.DeflateIO(romfile, deflate.GZIP)
                 try:
-                    self.romdata = memoryview(stream.read())
+                    stream.readinto(romview)
                 finally:
                     stream.close()
             finally:
                 romfile.close()
+            self.romdata = romview
             self._parse_rom_memory()
             return
 

--- a/apps/micropython/ventilastation/installer.py
+++ b/apps/micropython/ventilastation/installer.py
@@ -185,9 +185,9 @@ def install_from_file(package_path, root=""):
         os.rename(staging, old_game_dir)
         for tmp_path, final in rom_renames:
             # A previous install may have left the other on-flash variant
-            # (plain .rom vs .rom.gz); director.load_rom() prefers the .gz,
+            # (plain .rom vs .romz); director.load_rom() prefers the .romz,
             # so a stale sibling would shadow the fresh rom.
-            sibling = final[:-3] if final.endswith(".rom.gz") else final + ".gz"
+            sibling = final[:-1] if final.endswith(".romz") else final + "z"
             try:
                 os.remove(sibling)
             except OSError:

--- a/apps/micropython/ventilastation/menurom.py
+++ b/apps/micropython/ventilastation/menurom.py
@@ -7,11 +7,11 @@ package would have no icon. Each package ships a one-strip menu-icon.rom
 install time, replacing the strip when a game is re-installed.
 
 The board cannot gzip-compress, so the merged rom is written as a plain
-roms/menu.rom and the tree's roms/menu.rom.gz is deleted afterwards --
-director.load_rom() prefers the .gz, so leaving it would shadow the merge.
+roms/menu.rom and the tree's roms/menu.romz is deleted afterwards --
+director.load_rom() prefers the .romz, so leaving it would shadow the merge.
 That preference is also the staleness signal: a system OTA restores
-menu.rom.gz, and refresh_from_packages() (run at boot) notices it, re-merges
-every stored package's icon into the fresh tree rom, and drops the .gz
+menu.romz, and refresh_from_packages() (run at boot) notices it, re-merges
+every stored package's icon into the fresh tree rom, and drops the .romz
 again. No network involved: the icon roms live in /packages.
 
 Container layout per docs/internals/rom-format.md.
@@ -116,17 +116,24 @@ def merge_icon(menu_data, icon_data):
 
 
 def _gunzip_file(path):
+    """Inflate a ".romz" file: a little-endian uint32 uncompressed size
+    followed by gzip data (see build_micropython_fs.py). Knowing the size
+    upfront lets this read into one preallocated buffer via readinto()
+    instead of DeflateIO.read()'s unsized read."""
     with open(path, "rb") as f:
+        size = struct.unpack("<I", f.read(4))[0]
         try:
             import deflate
-            stream = deflate.DeflateIO(f, deflate.GZIP)
-            try:
-                return stream.read()
-            finally:
-                stream.close()
         except ImportError:
             import zlib
             return zlib.decompress(f.read(), 47)
+        buffer = bytearray(size)
+        stream = deflate.DeflateIO(f, deflate.GZIP)
+        try:
+            stream.readinto(buffer)
+        finally:
+            stream.close()
+        return buffer
 
 
 def _exists(path):
@@ -138,37 +145,37 @@ def _exists(path):
 
 
 def load_menu_rom(roms_dir=ROMS_DIR):
-    """Current menu rom bytes, preferring the tree's .gz like the director
-    does. Returns (data, from_gz)."""
-    gz_path = roms_dir + "/menu.rom.gz"
-    if _exists(gz_path):
-        return _gunzip_file(gz_path), True
+    """Current menu rom bytes, preferring the tree's .romz like the director
+    does. Returns (data, from_romz)."""
+    romz_path = roms_dir + "/menu.romz"
+    if _exists(romz_path):
+        return _gunzip_file(romz_path), True
     with open(roms_dir + "/menu.rom", "rb") as f:
         return f.read(), False
 
 
-def _write_menu_rom(data, roms_dir, drop_gz):
+def _write_menu_rom(data, roms_dir, drop_romz):
     tmp_path = roms_dir + "/menu.rom.tmp"
     with open(tmp_path, "wb") as f:
         f.write(data)
     os.rename(tmp_path, roms_dir + "/menu.rom")
-    if drop_gz:
+    if drop_romz:
         try:
-            os.remove(roms_dir + "/menu.rom.gz")
+            os.remove(roms_dir + "/menu.romz")
         except OSError:
             pass
 
 
 def merge_icon_into_menu(icon_data, roms_dir=ROMS_DIR):
-    menu_data, from_gz = load_menu_rom(roms_dir)
-    _write_menu_rom(merge_icon(menu_data, icon_data), roms_dir, drop_gz=from_gz)
+    menu_data, from_romz = load_menu_rom(roms_dir)
+    _write_menu_rom(merge_icon(menu_data, icon_data), roms_dir, drop_romz=from_romz)
 
 
 def refresh_from_packages(packages_dir=PACKAGES_DIR, roms_dir=ROMS_DIR):
     """Re-merge stored package icons after a system OTA restored
-    roms/menu.rom.gz. Cheap no-op (two stats) on a normal boot. Returns True
+    roms/menu.romz. Cheap no-op (two stats) on a normal boot. Returns True
     when a re-merge happened."""
-    if not _exists(roms_dir + "/menu.rom.gz"):
+    if not _exists(roms_dir + "/menu.romz"):
         return False
     try:
         packages = [
@@ -180,7 +187,7 @@ def refresh_from_packages(packages_dir=PACKAGES_DIR, roms_dir=ROMS_DIR):
     if not packages:
         return False
 
-    menu_data = _gunzip_file(roms_dir + "/menu.rom.gz")
+    menu_data = _gunzip_file(roms_dir + "/menu.romz")
     for name in sorted(packages):
         try:
             with vszip.ZipReader(packages_dir + "/" + name) as package:
@@ -188,5 +195,5 @@ def refresh_from_packages(packages_dir=PACKAGES_DIR, roms_dir=ROMS_DIR):
                     menu_data = merge_icon(menu_data, package.read(ICON_MEMBER))
         except Exception as e:
             print("menurom: skipping icon from", name, ":", e)
-    _write_menu_rom(menu_data, roms_dir, drop_gz=True)
+    _write_menu_rom(menu_data, roms_dir, drop_romz=True)
     return True

--- a/docs/internals/game-packages.md
+++ b/docs/internals/game-packages.md
@@ -30,7 +30,7 @@ merger rather than extracted:
 | Member | Zip method |
 |---|---|
 | `games/<g>/<n>/meta.json`, `games/<g>/<n>/code/**.py` | DEFLATE |
-| `roms/<slug>.rom.gz` (gzip -9, mtime 0 — the board cannot compress) | STORE |
+| `roms/<slug>.romz` (uint32 LE size + gzip -9, mtime 0 — see [rom-format.md](rom-format.md#on-flash-variant); the board cannot compress) | STORE |
 | `menu-icon.rom` | DEFLATE |
 
 ## Flow
@@ -74,9 +74,9 @@ The launcher renders all icons from one monolithic rom and
 games' icons must live inside `roms/menu.rom`. `ventilastation/menurom.py`
 splices each package's icon strip + palette in (replace-by-name on
 re-install, unreferenced palettes garbage-collected). Because the board
-cannot gzip and `director.load_rom()` prefers `menu.rom.gz`, the merged rom
-is written plain and the `.gz` is deleted — and the `.gz` reappearing after
-a system OTA is exactly the re-merge signal: `main.py` calls
+cannot gzip and `director.load_rom()` prefers `menu.romz`, the merged rom
+is written plain and the `.romz` is deleted — and the `.romz` reappearing
+after a system OTA is exactly the re-merge signal: `main.py` calls
 `menurom.refresh_from_packages()` at boot, which rebuilds the merged rom
 from the icon roms stored in `/packages/*.no-sound.vs2` (no network
 needed). `ventilastation/menu.py` falls back to a generic strip if an icon
@@ -151,8 +151,8 @@ NVS (`make wifi-provision`), repo on `feature/game-packages` with `.venv`.
    The board reboots twice (into install mode, then after install).
    - Menu must still show Vyruss VS2 with its icon (the merged menu rom).
    - `mpremote fs ls :/packages` shows `alecu.vyruss_vs2.no-sound.vs2`;
-     `:/roms` has `alecu.vyruss_vs2.rom.gz` and a plain `menu.rom` (no
-     `menu.rom.gz` anymore).
+     `:/roms` has `alecu.vyruss_vs2.romz` and a plain `menu.rom` (no
+     `menu.romz` anymore).
    - Game plays; shoot/explosion sounds come from the base ("Loaded N
      sounds from package ..." in the emulator log after upload).
    - This exercises LittleFS **directory rename** (staging → final). If
@@ -162,7 +162,7 @@ NVS (`make wifi-provision`), repo on `feature/game-packages` with `.venv`.
    copy `games/alecu/mapdemo` to `games/alecu/mapdemo2`, `package_game
    alecu/mapdemo2`, delete the copy) and install it: a brand-new
    `/games/alecu/mapdemo2` must appear in the menu with its icon.
-4. **OTA re-merge.** Ctrl-U again (tree OTA restores `roms/menu.rom.gz`).
+4. **OTA re-merge.** Ctrl-U again (tree OTA restores `roms/menu.romz`).
    After the post-OTA reboot the console must print
    `main: menu rom re-merged from installed packages` and installed icons
    must still render. Note vyruss_vs2's `code/` is re-synced from the tree

--- a/docs/internals/on-device-design.md
+++ b/docs/internals/on-device-design.md
@@ -163,9 +163,12 @@ Boy from one 0.92 MB app. NES sets `app->frameskip = 0`
 
 MicroPython sprite ROMs (`apps/micropython/roms/*.rom`, generated from PNGs by
 `tools/generate_roms.py`) are palette-indexed image data and compress ~85% with
-deflate. `build_micropython_fs.py` stores each as **`<name>.rom.gz`** (gzip) in
-the vfs image; `director.py` finds the `.gz` file and inflates it with the
-board's `deflate` module, parsing it in RAM. Repo `.rom` files stay
+deflate. `build_micropython_fs.py` stores each as **`<name>.romz`** (a
+little-endian uint32 uncompressed size followed by gzip data) in the vfs
+image; `director.py` finds the `.romz` file, reads the size, and inflates
+it directly into one preallocated buffer via the board's `deflate` module's
+`readinto()` — knowing the size upfront avoids the unsized `.read()`'s
+repeated reallocation/copying as the result grows. Repo `.rom` files stay
 uncompressed, so the desktop/web emulators are unaffected. This freed ~2.4 MB of
 the vfs partition — leaving room for the fMSX app partition and console ROMs.
 

--- a/docs/internals/ota.md
+++ b/docs/internals/ota.md
@@ -204,14 +204,16 @@ The file manifest reuses `hardware/rotor/build_micropython_fs.py`'s
 image — so OTA and USB deploys can never drift apart. It covers `main.py`,
 `ventilastation/`, sprite ROMs, Doom WADs, console ROMs, `games/` and
 `system/`, with the same skip rules. Sprite `.rom` files get the same
-deterministic gzip transform as the image and appear as `.rom.gz`.
+deterministic length-prefixed-gzip transform as the image and appear as
+`.romz` (see [rom-format.md](rom-format.md#on-flash-variant)); MSX
+cartridge/BIOS `.rom` files keep the older bare-gzip `.rom.gz` form.
 
 ```json
 {
   "files": [
     {"path": "ventilastation/director.py", "size": 4120, "sha256": "aabbcc..."},
     {"path": "games/alecu/vyruss/code/__init__.py", "size": 9311, "sha256": "..."},
-    {"path": "roms/menu.rom.gz", "size": 68210, "sha256": "..."}
+    {"path": "roms/menu.romz", "size": 68214, "sha256": "..."}
   ],
   "partitions": {
     "prboom-go":   {"size": 1245184, "sha256": "...", "url": "/partitions/prboom-go"},

--- a/docs/internals/rom-format.md
+++ b/docs/internals/rom-format.md
@@ -62,7 +62,24 @@ conventionally magenta and unused because index 0xFF means transparent.
 
 ## On-flash variant
 
-The LittleFS image stores ROMs gzip-compressed as `<name>.rom.gz`
-(hardware/rotor/build_micropython_fs.py); `director.load_rom()` looks for
-the `.gz` first and inflates it in memory. The uncompressed container is
-identical.
+The LittleFS image stores ROMs compressed as `<name>.romz`
+(`hardware/rotor/build_micropython_fs.py`'s `compress_sprite_rom()`):
+
+```
++--------------------------------------------------+
+| u32 uncompressed_size                             |
+| gzip data (the container above, compressed)       |
++--------------------------------------------------+
+```
+
+`director.load_rom()` looks for the `.romz` first, reads the size, and
+inflates directly into one preallocated buffer via
+`deflate.DeflateIO.readinto()` -- knowing the size upfront avoids
+`DeflateIO.read()`'s unsized read, which reallocates and copies repeatedly
+as the result grows. `menurom.py`'s `roms/menu.romz` uses the same format.
+The uncompressed container is otherwise identical.
+
+MSX cartridge/BIOS dumps (`roms/msx/*.rom`, `retro-go/bios/msx/*.rom`) are
+a separate case: fMSX reads those directly as a bare gzip stream (via
+zlib's `gzFile`), so they keep the old plain-gzip `.rom.gz` form with no
+size prefix -- see `build_micropython_fs.py`'s `is_sprite_rom_path()`.

--- a/emulator/package_manager.py
+++ b/emulator/package_manager.py
@@ -14,7 +14,8 @@ Stripped .no-sound.vs2 members are device paths (minus the leading "/"),
 except menu-icon.rom which the board merges into its menu rom instead of
 extracting:
     games/<group>/<name>/meta.json, games/<group>/<name>/code/**.py,
-    roms/<slug>.rom.gz (STORE, pre-gzipped), menu-icon.rom
+    roms/<slug>.romz (STORE, pre-gzipped, uint32-length-prefixed --
+    see hardware/rotor/build_micropython_fs.py), menu-icon.rom
 
 Everything here is import-light (stdlib only) so the standalone
 upgrade_server keeps working without the emulator's dependencies.
@@ -26,6 +27,7 @@ import io
 import json
 import pathlib
 import re
+import struct
 import threading
 import zipfile
 
@@ -210,11 +212,16 @@ def _build_board_file(slug, source_path):
                     member.startswith("code/") and member.endswith(".py")):
                 add(device_prefix + member, source.read(member))
             elif member == "roms/%s.rom" % slug:
-                # Pre-gzipped like the flashed image (the board can't
-                # compress); already-compressed data is STOREd in the zip.
-                payload = gzip.compress(source.read(member),
-                                        compresslevel=9, mtime=0)
-                add(member + ".gz", payload, zipfile.ZIP_STORED)
+                # Pre-compressed like the flashed image (the board can't
+                # compress): uint32 LE uncompressed size + gzip data, so
+                # director.load_rom() can preallocate and readinto() it
+                # directly -- see build_micropython_fs.py's
+                # compress_sprite_rom(). Already-compressed data is STOREd
+                # in the zip.
+                rom = source.read(member)
+                payload = struct.pack("<I", len(rom)) + gzip.compress(
+                    rom, compresslevel=9, mtime=0)
+                add(member + "z", payload, zipfile.ZIP_STORED)
             elif member == "menu-icon.rom":
                 add(member, source.read(member))
             # menu.png and sounds/* stay on the base.

--- a/emulator/upgrade_server.py
+++ b/emulator/upgrade_server.py
@@ -130,11 +130,12 @@ def _lfs_files():
             yield remote_path, local_path
 
 
-def _file_entry(device_path, local_path):
+def _file_entry(device_path, remote_path, local_path):
     """Return the cached {sha256, size, gz} entry for one file, refreshing
-    it when the source file changed. Sprite ROMs are stored gzip-compressed
-    on device (see build_micropython_fs.py), so they are hashed and served
-    in their compressed form under a ".rom.gz" device path."""
+    it when the source file changed. Sprite ROMs and MSX cartridge/BIOS
+    dumps are stored gzip-compressed on device (see build_micropython_fs.py),
+    so they are hashed and served in their compressed form under a ".romz"
+    or ".rom.gz" device path respectively."""
     stat = local_path.stat()
     key = (stat.st_mtime_ns, stat.st_size)
     with _cache_lock:
@@ -143,7 +144,10 @@ def _file_entry(device_path, local_path):
             return entry
     data = local_path.read_bytes()
     gz = None
-    if device_path.endswith(".rom.gz"):
+    if _build_fs.is_sprite_rom_path(remote_path):
+        gz = _build_fs.compress_sprite_rom(data)
+        data = gz
+    elif device_path.endswith(".rom.gz"):
         # mtime=0 keeps the output deterministic, matching the flashed image.
         gz = gzip.compress(data, compresslevel=9, mtime=0)
         data = gz
@@ -167,6 +171,8 @@ def _sha256_file(path):
 
 
 def _device_path(remote_path):
+    if _build_fs.is_sprite_rom_path(remote_path):
+        return remote_path + "z"
     return remote_path + ".gz" if remote_path.endswith(".rom") else remote_path
 
 
@@ -176,7 +182,7 @@ def _build_manifest():
         if not local_path.is_file():
             continue
         device_path = _device_path(remote_path)
-        entry = _file_entry(device_path, local_path)
+        entry = _file_entry(device_path, remote_path, local_path)
         files.append({
             "path": device_path,
             "size": entry["size"],
@@ -203,7 +209,7 @@ def _read_device_file(rel):
             continue
         if not local_path.is_file():
             return None
-        entry = _file_entry(rel, local_path)
+        entry = _file_entry(rel, remote_path, local_path)
         if entry["gz"] is not None:
             return entry["gz"]
         return local_path.read_bytes()

--- a/hardware/rotor/build_micropython_fs.py
+++ b/hardware/rotor/build_micropython_fs.py
@@ -5,6 +5,7 @@ import argparse
 import gzip
 import os
 import pathlib
+import struct
 import sys
 
 BLOCK_SIZE = 4096  # SPI flash sector size on ESP32
@@ -44,6 +45,26 @@ ROM_SUFFIXES = {
     ".rom", ".mx1", ".mx2", ".dsk", ".cas", ".fdi", ".gz",
 }
 EMU_ROM_ROOTS = {"roms/nes", "roms/sms", "roms/gb", "roms/msx"}
+
+# Paths under EMU_ROM_ROOTS that end in ".rom" (MSX cartridge/BIOS dumps) are
+# read directly by fMSX via zlib's gzFile (see MSX.c's fread->gzread remap),
+# which expects a bare gzip stream -- so they keep the old plain-gzip,
+# ".rom.gz" on-flash form. Sprite ROMs (ventilastation's own image format,
+# read by director.load_rom()/menurom.py) get the length-prefixed ".romz"
+# form instead; see compress_sprite_rom() and docs/internals/rom-format.md.
+_NON_SPRITE_ROM_PREFIXES = ("roms/msx/", "retro-go/bios/msx/")
+
+
+def is_sprite_rom_path(remote_path):
+    return remote_path.endswith(".rom") and not remote_path.startswith(_NON_SPRITE_ROM_PREFIXES)
+
+
+def compress_sprite_rom(data):
+    """<uint32 LE uncompressed size><gzip data>. The size lets director.py
+    preallocate one exact-sized buffer and deflate.DeflateIO.readinto() it
+    directly, instead of DeflateIO.read()'s unsized read -- which reallocates
+    and copies repeatedly as it grows, the slow path this format replaces."""
+    return struct.pack("<I", len(data)) + gzip.compress(data, compresslevel=9, mtime=0)
 
 
 def iter_copy_jobs(vsdk_root):
@@ -130,11 +151,18 @@ def build_image(vsdk_root, partition_size, output_path, empty=False):
             with open(local_path, "rb") as f_in:
                 data = f_in.read()
             # Sprite ROMs are palette-indexed image data and compress ~85% with
-            # deflate. Store them gzip-compressed under a ".rom.gz" name (so they
-            # are not confused with raw ROMs) to save flash; director.py finds the
-            # ".gz" file and inflates it via the `deflate` module. mtime=0 keeps
-            # the image reproducible.
-            if lfs_path.endswith(".rom"):
+            # deflate. Store them length-prefixed-gzip-compressed under a
+            # ".romz" name (so they are not confused with raw ROMs) to save
+            # flash; director.py/menurom.py find the ".romz" file and inflate
+            # it via the `deflate` module.
+            if is_sprite_rom_path(remote_path):
+                payload = compress_sprite_rom(data)
+                lfs_path += "z"
+                print(f"  add   {lfs_path}  ({len(data):,} -> {len(payload):,} incl. header, gzip)")
+                data = payload
+            elif lfs_path.endswith(".rom"):
+                # MSX cartridge/BIOS dumps: fMSX reads these as a bare gzip
+                # stream (see is_sprite_rom_path()), so no length header.
                 compressed = gzip.compress(data, compresslevel=9, mtime=0)
                 lfs_path += ".gz"
                 print(f"  add   {lfs_path}  ({len(data):,} -> {len(compressed):,} gzip)")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import struct
 import sys
 import tempfile
 import unittest
@@ -17,9 +18,9 @@ SLUG = "alecu.testgame"
 PREFIX = "games/alecu/testgame"
 
 
-def game_rom_gz():
+def game_rom_z():
     rom = build_rom([("ship.png", 8, 8, 2, 0, 5)], [build_palette(20)])
-    return gzip.compress(rom, 9, mtime=0)
+    return struct.pack("<I", len(rom)) + gzip.compress(rom, 9, mtime=0)
 
 
 def write_stripped_package(path, extra_members=(), icon=True):
@@ -27,9 +28,9 @@ def write_stripped_package(path, extra_members=(), icon=True):
         archive.writestr(PREFIX + "/meta.json", b'{"api": "vs2", "order": 5}')
         archive.writestr(PREFIX + "/code/testgame.py", b"def main():\n    return None\n")
         archive.writestr(PREFIX + "/code/helpers/util.py", b"VALUE = 1\n")
-        info = zipfile.ZipInfo("roms/%s.rom.gz" % SLUG)
+        info = zipfile.ZipInfo("roms/%s.romz" % SLUG)
         info.compress_type = zipfile.ZIP_STORED
-        archive.writestr(info, game_rom_gz())
+        archive.writestr(info, game_rom_z())
         if icon:
             archive.writestr("menu-icon.rom", icon_fixture(name="alecu/testgame/menu.png"))
         for name, data in extra_members:
@@ -61,7 +62,7 @@ class InstallFromFileTests(unittest.TestCase):
         self.assertEqual(self._read(PREFIX + "/meta.json"),
                          b'{"api": "vs2", "order": 5}')
         self.assertEqual(self._read(PREFIX + "/code/helpers/util.py"), b"VALUE = 1\n")
-        self.assertEqual(self._read("roms/%s.rom.gz" % SLUG), game_rom_gz())
+        self.assertEqual(self._read("roms/%s.romz" % SLUG), game_rom_z())
         strip_names = [s[0] for s in inventory(self._read("roms/menu.rom"))[0]]
         self.assertIn("alecu/testgame/menu.png", strip_names)
         # No staging leftovers where the catalog could discover them.
@@ -74,7 +75,7 @@ class InstallFromFileTests(unittest.TestCase):
         with open(os.path.join(old_dir, "code", "stale.py"), "w") as f:
             f.write("OLD = True\n")
         # A previous scheme left a plain rom; it would shadow nothing itself,
-        # but the fresh .rom.gz must not coexist with a stale sibling.
+        # but the fresh .romz must not coexist with a stale sibling.
         with open(os.path.join(self.root, "roms", "%s.rom" % SLUG), "wb") as f:
             f.write(b"stale plain rom")
 
@@ -82,7 +83,7 @@ class InstallFromFileTests(unittest.TestCase):
 
         self.assertFalse(os.path.exists(os.path.join(old_dir, "code", "stale.py")))
         self.assertFalse(os.path.exists(os.path.join(self.root, "roms", "%s.rom" % SLUG)))
-        self.assertTrue(os.path.exists(os.path.join(self.root, "roms", "%s.rom.gz" % SLUG)))
+        self.assertTrue(os.path.exists(os.path.join(self.root, "roms", "%s.romz" % SLUG)))
         self.assertEqual(self._read(PREFIX + "/code/testgame.py"),
                          b"def main():\n    return None\n")
 

--- a/tests/test_installer_micropython.py
+++ b/tests/test_installer_micropython.py
@@ -37,32 +37,33 @@ ZIP_FIXTURE = binascii.a2b_base64(
     b"wQEAAHNvdW5kcy9yYXcubXAzUEsFBgAAAAADAAMArAAAAP0BAAAAAA=="
 )
 
-# gzip of a menu rom holding strips "menu.png" + "alecu/vyruss_vs2/menu.png"
-# sharing one palette (what a tree OTA would restore as roms/menu.rom.gz)
-MENU_GZ_FIXTURE = binascii.a2b_base64(
-    b"H4sIAAAAAAAC/+3YQQpAQACF4Tez0qxmyUI5AWXrMJJkwyTTKKfHxiX4v/rfIZ6VkZdU"
-    b"PtPlUrZOIdVbmL33MgAAAAAA4POKYZnG1BznnmLsj9g27ztQVVYWAAD8zuWcI6J/dgMV"
-    b"ynHsOxwAAA=="
+# menu rom holding strips "menu.png" + "alecu/vyruss_vs2/menu.png" sharing
+# one palette, as ".romz" (uint32 LE uncompressed size + gzip data -- what a
+# tree OTA would restore as roms/menu.romz; see build_micropython_fs.py)
+MENU_ROMZ_FIXTURE = binascii.a2b_base64(
+    b"OxwAAB+LCAAAAAAAAv/t2EEKQEAAheE3s9KsZslCOQFl6zCSZMMk0yinx8Yl+L/63yGe"
+    b"lZGXVD7T5VK2TiHVW5i99zIAAAAAAODzimGZxtQc555i7I/YNu87UFVWFgAA/M7lnCOi"
+    b"f3YDFcpx7DscAAA="
 )
 
 # stripped package (.no-sound.vs2) for games/alecu/newgame: meta + code
-# (DEFLATE), roms/alecu.newgame.rom.gz (STORE, 1177-byte rom inside),
-# menu-icon.rom (strip "alecu/newgame/menu.png" + own palette)
+# (DEFLATE), roms/alecu.newgame.romz (STORE, uint32 LE size + gzip of the
+# 1177-byte rom), menu-icon.rom (strip "alecu/newgame/menu.png" + own palette)
 STRIPPED_FIXTURE = binascii.a2b_base64(
     b"UEsDBBQAAAAIAAAAIQAR1m/fGgAAABoAAAAdAAAAZ2FtZXMvYWxlY3UvbmV3Z2FtZS9t"
     b"ZXRhLmpzb26rVkosyFSyUlAqKzZS0lFQyi9KSS0C8s1rAVBLAwQUAAAACAAAACEA8FPT"
     b"RxwAAAAcAAAAIwAAAGdhbWVzL2FsZWN1L25ld2dhbWUvY29kZS9uZXdnYW1lLnB5S0lN"
-    b"U8hNzMzT0LTiUgCCotSS0qI8Bb/8vFQuAFBLAwQUAAAAAAAAACEAlUfzhjoAAAA6AAAA"
-    b"GQAAAHJvbXMvYWxlY3UubmV3Z2FtZS5yb20uZ3ofiwgAAAAAAAL/Y2RgZOBhYGCYCcQc"
-    b"xRmZBXoFeekcHEwMrAMM/ouIiIziUTyKRyYGABJtWoOZBAAAUEsDBBQAAAAIAAAAIQDQ"
-    b"oSLVQwAAACcUAAANAAAAbWVudS1pY29uLnJvbe3DMQqAMBBFwR+0tLCyTmdnzhSWJY1Z"
-    b"bILH13voG5ikpEXSvkpbPd1GCb9b7V66xziuaDnPmgAAAAAAwOc9Zkbyn19QSwECFAMU"
-    b"AAAACAAAACEAEdZv3xoAAAAaAAAAHQAAAAAAAAAAAAAAgAEAAAAAZ2FtZXMvYWxlY3Uv"
-    b"bmV3Z2FtZS9tZXRhLmpzb25QSwECFAMUAAAACAAAACEA8FPTRxwAAAAcAAAAIwAAAAAA"
-    b"AAAAAAAAgAFVAAAAZ2FtZXMvYWxlY3UvbmV3Z2FtZS9jb2RlL25ld2dhbWUucHlQSwEC"
-    b"FAMUAAAAAAAAACEAlUfzhjoAAAA6AAAAGQAAAAAAAAAAAAAAgAGyAAAAcm9tcy9hbGVj"
-    b"dS5uZXdnYW1lLnJvbS5nelBLAQIUAxQAAAAIAAAAIQDQoSLVQwAAACcUAAANAAAAAAAA"
-    b"AAAAAACAASMBAABtZW51LWljb24ucm9tUEsFBgAAAAAEAAQAHgEAAJEBAAAAAA=="
+    b"U8hNzMzT0LTiUgCCotSS0qI8Bb/8vFQuAFBLAwQUAAAAAAAAACEAEkOhHj4AAAA+AAAA"
+    b"FwAAAHJvbXMvYWxlY3UubmV3Z2FtZS5yb216mQQAAB+LCAAAAAAAAv9jZGBk4GFgYJgJ"
+    b"xBzFGZkFegV56RwcTAysAwz+i4iIjOJRPIpHJgYAEm1ag5kEAABQSwMEFAAAAAgAAAAh"
+    b"ANChItVDAAAAJxQAAA0AAABtZW51LWljb24ucm9t7cMxCoAwEEXBH7S0sLJOZ2fOFJYl"
+    b"jVlsgsfXe+gbmKSkRdK+Sls93UYJv1vtXrrHOK5oOc+aAAAAAADA5z1mRvKfX1BLAQIU"
+    b"AxQAAAAIAAAAIQAR1m/fGgAAABoAAAAdAAAAAAAAAAAAAACAAQAAAABnYW1lcy9hbGVj"
+    b"dS9uZXdnYW1lL21ldGEuanNvblBLAQIUAxQAAAAIAAAAIQDwU9NHHAAAABwAAAAjAAAA"
+    b"AAAAAAAAAACAAVUAAABnYW1lcy9hbGVjdS9uZXdnYW1lL2NvZGUvbmV3Z2FtZS5weVBL"
+    b"AQIUAxQAAAAAAAAAIQASQ6EePgAAAD4AAAAXAAAAAAAAAAAAAACAAbIAAAByb21zL2Fs"
+    b"ZWN1Lm5ld2dhbWUucm9telBLAQIUAxQAAAAIAAAAIQDQoSLVQwAAACcUAAANAAAAAAAA"
+    b"AAAAAACAASUBAABtZW51LWljb24ucm9tUEsFBgAAAAAEAAQAHAEAAJMBAAAAAA=="
 )
 
 ROOT_DIR = "build/test_mp_root"
@@ -111,7 +112,7 @@ def test_vszip_reads_store_and_deflate():
 
 def test_install_from_stripped_package():
     _reset_root()
-    _write(ROOT_DIR + "/roms/menu.rom.gz", MENU_GZ_FIXTURE)
+    _write(ROOT_DIR + "/roms/menu.romz", MENU_ROMZ_FIXTURE)
     package_path = ROOT_DIR + "/alecu.newgame.no-sound.vs2"
     _write(package_path, STRIPPED_FIXTURE)
 
@@ -120,9 +121,9 @@ def test_install_from_stripped_package():
     assert slug == "alecu.newgame", slug
     assert _read(ROOT_DIR + "/games/alecu/newgame/meta.json") == b'{"api": "vs2", "order": 7}'
     assert _read(ROOT_DIR + "/games/alecu/newgame/code/newgame.py").startswith(b"def main()")
-    assert _exists(ROOT_DIR + "/roms/alecu.newgame.rom.gz")
-    # Icon merged: plain menu rom written, the shadowing .gz dropped.
-    assert not _exists(ROOT_DIR + "/roms/menu.rom.gz")
+    assert _exists(ROOT_DIR + "/roms/alecu.newgame.romz")
+    # Icon merged: plain menu rom written, the shadowing .romz dropped.
+    assert not _exists(ROOT_DIR + "/roms/menu.romz")
     menu = _read(ROOT_DIR + "/roms/menu.rom")
     strips, palettes = menurom.parse(menu)
     names = [strip[0] for strip in strips]

--- a/tests/test_menurom.py
+++ b/tests/test_menurom.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import struct
 import sys
 import tempfile
 import unittest
@@ -111,8 +112,8 @@ class MenuRomFileTests(unittest.TestCase):
         self._tmp.cleanup()
 
     def _write_gz(self, data):
-        with open(os.path.join(self.roms_dir, "menu.rom.gz"), "wb") as f:
-            f.write(gzip.compress(data, 9, mtime=0))
+        with open(os.path.join(self.roms_dir, "menu.romz"), "wb") as f:
+            f.write(struct.pack("<I", len(data)) + gzip.compress(data, 9, mtime=0))
 
     def _write_plain(self, data):
         with open(os.path.join(self.roms_dir, "menu.rom"), "wb") as f:
@@ -131,7 +132,7 @@ class MenuRomFileTests(unittest.TestCase):
     def test_merge_into_gz_writes_plain_and_drops_gz(self):
         self._write_gz(menu_fixture())
         menurom.merge_icon_into_menu(icon_fixture(), roms_dir=self.roms_dir)
-        self.assertFalse(os.path.exists(os.path.join(self.roms_dir, "menu.rom.gz")))
+        self.assertFalse(os.path.exists(os.path.join(self.roms_dir, "menu.romz")))
         strips, _ = inventory(self._read_plain())
         self.assertEqual(len(strips), 3)
 
@@ -150,7 +151,7 @@ class MenuRomFileTests(unittest.TestCase):
             packages_dir=self.packages_dir, roms_dir=self.roms_dir)
 
         self.assertTrue(refreshed)
-        self.assertFalse(os.path.exists(os.path.join(self.roms_dir, "menu.rom.gz")))
+        self.assertFalse(os.path.exists(os.path.join(self.roms_dir, "menu.romz")))
         strips, _ = inventory(self._read_plain())
         self.assertEqual(len(strips), 3)
 
@@ -163,7 +164,7 @@ class MenuRomFileTests(unittest.TestCase):
         self.assertFalse(menurom.refresh_from_packages(
             packages_dir=self.packages_dir, roms_dir=self.roms_dir))
         # No packages stored: the tree .gz stays authoritative.
-        self.assertTrue(os.path.exists(os.path.join(self.roms_dir, "menu.rom.gz")))
+        self.assertTrue(os.path.exists(os.path.join(self.roms_dir, "menu.romz")))
 
 
 if __name__ == "__main__":

--- a/tests/test_package_server.py
+++ b/tests/test_package_server.py
@@ -2,6 +2,7 @@ import gzip
 import io
 import json
 import pathlib
+import struct
 import sys
 import tempfile
 import unittest
@@ -41,6 +42,43 @@ def make_package_bytes(slug=SLUG, code=b"def main():\n    return None\n",
         for member, data in extra_members:
             archive.writestr(member, data)
     return out.getvalue()
+
+
+class DevicePathTests(unittest.TestCase):
+    """upgrade_server's _device_path()/_file_entry() drive the system OTA
+    manifest; a sprite rom must get the same length-prefixed ".romz" form
+    build_micropython_fs.py flashes, so a dev-loop OTA and a fresh flash
+    agree byte-for-byte. MSX cartridge/BIOS dumps keep the old bare-gzip
+    ".rom.gz" form, since fMSX reads those directly via zlib's gzFile."""
+
+    def test_sprite_rom_gets_length_prefixed_romz(self):
+        rom = build_rom([("ship.png", 8, 8, 2, 0, 5)], [build_palette(20)])
+        with tempfile.TemporaryDirectory() as tmp:
+            rom_path = pathlib.Path(tmp) / "alecu.testgame.rom"
+            rom_path.write_bytes(rom)
+
+            remote_path = "roms/alecu.testgame.rom"
+            device_path = upgrade_server._device_path(remote_path)
+            self.assertEqual(device_path, "roms/alecu.testgame.romz")
+
+            entry = upgrade_server._file_entry(device_path, remote_path, rom_path)
+            self.assertIsNotNone(entry["gz"])
+            size = struct.unpack("<I", entry["gz"][:4])[0]
+            self.assertEqual(size, len(rom))
+            self.assertEqual(gzip.decompress(entry["gz"][4:]), rom)
+            self.assertEqual(entry["size"], len(entry["gz"]))
+
+    def test_msx_rom_keeps_bare_gzip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            rom_path = pathlib.Path(tmp) / "game.rom"
+            rom_path.write_bytes(b"fake msx cartridge dump")
+
+            remote_path = "roms/msx/game.rom"
+            device_path = upgrade_server._device_path(remote_path)
+            self.assertEqual(device_path, "roms/msx/game.rom.gz")
+
+            entry = upgrade_server._file_entry(device_path, remote_path, rom_path)
+            self.assertEqual(gzip.decompress(entry["gz"]), b"fake msx cartridge dump")
 
 
 class PackageServerTests(unittest.TestCase):
@@ -129,14 +167,16 @@ class PackageServerTests(unittest.TestCase):
                 "games/alecu/testgame/code/testgame.py",
                 "games/alecu/testgame/meta.json",
                 "menu-icon.rom",
-                "roms/%s.rom.gz" % SLUG,
+                "roms/%s.romz" % SLUG,
             ])
-            rom_info = stripped.getinfo("roms/%s.rom.gz" % SLUG)
+            rom_info = stripped.getinfo("roms/%s.romz" % SLUG)
             self.assertEqual(rom_info.compress_type, zipfile.ZIP_STORED)
             original_rom = build_rom([("ship.png", 8, 8, 2, 0, 5)],
                                      [build_palette(20)])
-            self.assertEqual(
-                gzip.decompress(stripped.read(rom_info)), original_rom)
+            payload = stripped.read(rom_info)
+            size = struct.unpack("<I", payload[:4])[0]
+            self.assertEqual(size, len(original_rom))
+            self.assertEqual(gzip.decompress(payload[4:]), original_rom)
 
         # Serving the board file marks the install as being fetched.
         self.assertEqual(package_manager.get_install_status(SLUG)["state"],


### PR DESCRIPTION
director.load_rom() inflated compressed ROMs with DeflateIO.read(), which has no size hint and reallocates/copies its growing result buffer repeatedly -- confirmed on real hardware to take 5.3s for a 746 KB ROM. The uncompressed codepath already knew its size upfront and used readinto() into one preallocated buffer instead.

Give the compressed path the same information: prefix the gzip data with a little-endian uint32 uncompressed size and rename the on-flash extension from .rom.gz to .romz, so director.py (and menurom.py, same format) can preallocate and readinto() directly. Confirmed on the same 746 KB ROM on real hardware: 5.3s -> 0.76s, byte-identical output.

MSX cartridge/BIOS .rom files are excluded from the new format (kept on the old bare-gzip .rom.gz) since fMSX reads those directly via zlib's gzFile, which expects a plain gzip stream with no size prefix.