### PR TITLE
Drop docs static/template paths that break the RTD build

### DIFF
--- a/docs/vs2/conf.py
+++ b/docs/vs2/conf.py
@@ -51,7 +51,6 @@ extensions = [
     "sphinx.ext.intersphinx",
 ]
 
-templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 source_suffix = {".md": "markdown", ".rst": "restructuredtext"}
@@ -77,7 +76,11 @@ napoleon_use_rtype = False
 
 html_theme = "furo"
 html_title = "Ventilastation VS2"
-html_static_path = ["_static"]
+# No html_static_path or templates_path on purpose: there are no custom assets
+# or template overrides yet, and git does not track empty directories -- so
+# naming one here builds fine locally and then fails the Read the Docs build
+# (which runs with fail_on_warning) on its clean checkout. Add the directory
+# and the setting together, in the same commit, if assets are ever needed.
 html_theme_options = {
     "source_repository": "https://github.com/ventilastation/vsdk/",
     "source_branch": "main",


### PR DESCRIPTION
The Read the Docs build failed on:

    WARNING: html_static_path entry '_static' does not exist

docs/vs2/_static was created empty and never held a file, so git did not track it. It existed locally but not in the clean checkout Read the Docs builds from, and .readthedocs.yaml sets fail_on_warning, so the warning became an error. templates_path pointed at a directory that never existed at all; Sphinx does not warn about that one, so it sat there as dead config.

Neither setting has anything to point at yet, so remove both rather than committing placeholder files, and record why in a comment so the pair is reintroduced together with real assets.

Verified by copying docs/vs2 and apps/micropython to a scratch tree, running `find -type d -empty -delete` to model what a clone actually produces, and building there with -W: clean. Building in place, which is what I did originally, cannot catch this class of failure.