### PR TITLE
Stop recovery reboot-looping when the base station is unreachable

### DIFF
--- a/apps/micropython/updater.py
+++ b/apps/micropython/updater.py
@@ -75,11 +75,35 @@ _NVS_KEYS = {
 }
 
 _comms_send = None   # set by run()
+_feed_wdt = None     # set by run()
 
 
 def _send(line):
     if _comms_send:
         _comms_send(line.encode() if isinstance(line, str) else line)
+
+
+def _prep_checkpoint():
+    """One step of the long, quiet stretch between "WiFi connecting" and the
+    first real file/partition total: bounce the on-device activity ring *and*
+    feed the caller's watchdog.
+
+    The two belong together. Everywhere else in this file the watchdog is fed
+    as a side effect of emitting a progress line (recovery's handler feeds on
+    every line it receives -- see vsdk_recovery._make_progress_handler), but
+    this phase deliberately emits none, so it used to feed nothing at all:
+    WiFi connect, address resolution, the manifest fetch and the .tmp scan
+    together ran for as long as they needed with recovery's 30s watchdog
+    counting down untouched, and anything slower than that rebooted the board
+    mid-attempt instead of failing into recovery's own backoff retry. That
+    also made _wifi_connect()'s indefinite retry unreachable in practice: its
+    red "wifi problem" ring needs three attempts (~24-36s), so the reboot
+    always won first. Keeping the ring pulse and the feed in one call is what
+    stops them drifting apart again.
+    """
+    vsdk_ota_rings.pulse_prep_activity()
+    if _feed_wdt:
+        _feed_wdt()
 
 
 def _progress(stage, detail, pct):
@@ -154,19 +178,153 @@ def _is_ipv4_literal(host):
     return True
 
 
-def _resolve_base_url(base_url):
+# mDNS multicast group/port, and how patiently to ask. Three tries at 2s
+# each keeps a whole resolution attempt well inside recovery's 30s watchdog
+# (see vsdk_recovery._WDT_TIMEOUT_MS) even when nothing answers at all.
+_MDNS_GROUP = "224.0.0.251"
+_MDNS_PORT = 5353
+_MDNS_TIMEOUT_MS = 2000
+_MDNS_ATTEMPTS = 3
+
+
+def _dns_skip_name(buf, i):
+    """Advance past the encoded name starting at i, returning the next index."""
+    while i < len(buf):
+        length = buf[i]
+        if length == 0:
+            return i + 1
+        if length & 0xC0 == 0xC0:
+            return i + 2  # a compression pointer is always the whole name
+        i += 1 + length
+    raise ValueError("truncated name")
+
+
+def _dns_read_name(buf, i, depth=0):
+    parts = []
+    while i < len(buf):
+        length = buf[i]
+        if length == 0:
+            break
+        if length & 0xC0 == 0xC0:
+            if depth > 4:
+                raise ValueError("compression pointer loop")
+            parts.append(_dns_read_name(buf, ((length & 0x3F) << 8) | buf[i + 1], depth + 1))
+            break
+        parts.append(bytes(buf[i + 1:i + 1 + length]).decode())
+        i += 1 + length
+    return ".".join(parts)
+
+
+def _mdns_parse_a(buf, host):
+    """Pull host's A record out of an mDNS response, or None if it has none.
+
+    Records are matched by name rather than taking the first A record in the
+    packet: a responder is free to bundle unrelated records (its own other
+    services, another host's announcement it happened to be sending) into the
+    same message, and answering with one of those would send the whole OTA
+    session to the wrong machine.
+    """
+    if len(buf) < 12:
+        return None
+    questions = (buf[4] << 8) | buf[5]
+    records = ((buf[6] << 8) | buf[7]) + ((buf[8] << 8) | buf[9]) + ((buf[10] << 8) | buf[11])
+    i = 12
+    for _ in range(questions):
+        i = _dns_skip_name(buf, i) + 4  # + QTYPE, QCLASS
+    wanted = host.lower().rstrip(".")
+    for _ in range(records):
+        name = _dns_read_name(buf, i)
+        i = _dns_skip_name(buf, i)
+        rtype = (buf[i] << 8) | buf[i + 1]
+        rdlength = (buf[i + 8] << 8) | buf[i + 9]
+        i += 10
+        if rtype == 1 and rdlength == 4 and name.lower().rstrip(".") == wanted:
+            return "%d.%d.%d.%d" % (buf[i], buf[i + 1], buf[i + 2], buf[i + 3])
+        i += rdlength
+    return None
+
+
+def _mdns_resolve(host, feed=None):
+    """Resolve a .local hostname with our own bounded mDNS query.
+
+    Not socket.getaddrinfo(): that call has no timeout of its own on this
+    port (unlike the socket itself), and on hardware it does not merely run
+    slowly -- while the POV display's GPU task is running (which in recovery
+    it always is, drawing the progress rings) a `.local` lookup never returns
+    at all. Measured on a rotor board, same session and network, seconds
+    apart: display off, `ventilastation-base.local` resolved in 0.4-0.5s
+    three times running; display on, the identical call never came back
+    (still blocked after ten minutes). Plain unicast DNS (10ms) and TCP to
+    the base station by IP (0.5s, HTTP 200) both stayed fine throughout, so
+    it is the multicast path specifically -- consistent with the GPU task
+    being a `while(true)` loop that never yields, pinned to a core at
+    priority 10 (see coreTask() in modules/povdisplay/povdisplay.c), and with
+    director.py's existing note that the normal OTA path reboots so the
+    transfer runs *before* that task starts.
+
+    Asking for a *unicast* response (the QU bit below) is what makes this
+    work where getaddrinfo doesn't: the reply comes back as an ordinary UDP
+    datagram to our own ephemeral port instead of arriving on the multicast
+    group, so nothing here depends on the receive path that breaks. The
+    socket timeout then bounds the whole thing, turning "base station is off"
+    into a normal ota_error and a recovery backoff retry rather than a hang.
+
+    feed, if given, is called between attempts -- a resolution that takes all
+    three tries still has to keep the caller's watchdog fed.
+    """
+    import utime
+
+    labels = b""
+    for part in host.split("."):
+        raw = part.encode()
+        labels += bytes([len(raw)]) + raw
+    labels += b"\x00"
+    # id 0 (mDNS responders ignore it), no flags, one question, QTYPE=A(1),
+    # QCLASS=IN(1) with the top "unicast response requested" bit set.
+    query = b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00" + labels + b"\x00\x01\x80\x01"
+    group = socket.getaddrinfo(_MDNS_GROUP, _MDNS_PORT)[0][-1]
+
+    for attempt in range(_MDNS_ATTEMPTS):
+        if feed:
+            feed()
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.settimeout(_MDNS_TIMEOUT_MS / 1000)
+            s.sendto(query, group)
+            deadline = utime.ticks_add(utime.ticks_ms(), _MDNS_TIMEOUT_MS)
+            while utime.ticks_diff(deadline, utime.ticks_ms()) > 0:
+                try:
+                    data, _addr = s.recvfrom(512)
+                except OSError:
+                    break  # timed out waiting for this attempt's answer
+                try:
+                    addr = _mdns_parse_a(data, host)
+                except (ValueError, IndexError):
+                    continue  # malformed packet from someone else on the group
+                if addr:
+                    return addr
+        except OSError as e:
+            print("updater: mDNS attempt %d failed:" % (attempt + 1), e)
+        finally:
+            s.close()
+    return None
+
+
+def _resolve_base_url(base_url, feed=None):
     """Resolve base_url's hostname to a numeric IP once, so every subsequent
     per-file/per-partition connection this session reuses it instead of
-    repeating a fresh DNS/mDNS lookup. socket.getaddrinfo() has no timeout of
-    its own on this port (unlike the socket itself), so a flaky mDNS
-    resolution can stall indefinitely; resolving once here -- right after
-    WiFi connects, before hundreds of per-file connections each get their own
-    chance to hit that -- bounds the exposure to one lookup per session
-    instead of one per file."""
+    repeating a fresh DNS/mDNS lookup -- bounding the exposure to one lookup
+    per session instead of one per file."""
     host, port, _path = _parse_url(base_url)
     if _is_ipv4_literal(host):
         return base_url
-    addr = socket.getaddrinfo(host, port)[0][-1][0]
+    if host.lower().endswith(".local"):
+        addr = _mdns_resolve(host, feed)
+        if not addr:
+            raise OSError("mDNS lookup for %s found nothing" % host)
+    else:
+        # Ordinary unicast DNS, which works fine alongside the GPU task.
+        addr = socket.getaddrinfo(host, port)[0][-1][0]
     print("updater: resolved", host, "->", addr)
     return base_url.replace(host, addr, 1)
 
@@ -219,12 +377,13 @@ def _cleanup_tmp_files():
     stack = ["/"]
     while stack:
         d = stack.pop()
-        # One pulse per directory -- this walk is the other real source of
-        # "quiet time" between WiFi connecting and file-sync's own progress
-        # ring (see run()'s prep-ring comment); most boards have few enough
-        # directories that this barely matters, but it keeps the ring alive
-        # instead of static on any board with more of them.
-        vsdk_ota_rings.pulse_prep_activity()
+        # One checkpoint per directory -- this walk is the other real source
+        # of "quiet time" between WiFi connecting and file-sync's own
+        # progress ring (see run()'s prep-ring comment); most boards have few
+        # enough directories that this barely matters, but it keeps the ring
+        # alive (and the watchdog fed) instead of static on any board with
+        # more of them.
+        _prep_checkpoint()
         try:
             for name, ftype, *_ in os.ilistdir(d):
                 full = d.rstrip("/") + "/" + name
@@ -704,6 +863,8 @@ def _wifi_connect():
             vsdk_ota_rings.show_wifi_problem()
         else:
             vsdk_ota_rings.show_wifi_connecting()
+        if _feed_wdt:
+            _feed_wdt()
         print("updater: connecting WiFi to", ssid, "(attempt %d)" % attempt)
         try:
             # A bad password or a driver-level hiccup (e.g. repeated failed
@@ -721,6 +882,8 @@ def _wifi_connect():
                     return True
                 utime.sleep_ms(500)
                 waited_ms += 500
+                if _feed_wdt:
+                    _feed_wdt()
         except Exception as e:
             print("updater: WiFi attempt %d failed:" % attempt, e)
             # Also confirmed on hardware: without this, an immediately-
@@ -743,14 +906,29 @@ def _wifi_disconnect():
         pass
 
 
-def run(base_url, send_fn):
+def run(base_url, send_fn, feed_fn=None, disconnect_wifi=True):
     """Run the full 3-tier OTA update.
 
     base_url  — e.g. "http://192.168.1.5:5653"
     send_fn   — callable that sends a bytes line back over the comms channel
+    feed_fn   — optional zero-arg callable that feeds the caller's watchdog.
+                Needed for the prep phase specifically (see
+                _prep_checkpoint()); every later stage already feeds it
+                indirectly, by way of the progress lines it sends.
+    disconnect_wifi — tear the link down again on the way out (only if we
+                brought it up). False for a caller that is about to retry
+                anyway: recovery loops here every few seconds, and bringing
+                WiFi down and straight back up each time costs real seconds
+                and, with the GPU task running, is where an attempt that had
+                already failed cleanly still went on to trip the watchdog --
+                measured on hardware, ota_error at t+16s then a WDT reset at
+                t+46s, exactly 30s later, with nothing in between. Nothing in
+                recovery needs the link down: it either retries or reboots,
+                and a reboot drops WiFi regardless.
     """
-    global _comms_send
+    global _comms_send, _feed_wdt
     _comms_send = send_fn
+    _feed_wdt = feed_fn
 
     print("updater: starting OTA from", base_url)
     _send("ota_progress start fetching_manifest 0\n")
@@ -776,14 +954,14 @@ def run(base_url, send_fn):
     # stall. pulse_prep_activity() gives this stretch its own bouncing
     # ring, pulsed at each checkpoint below; hide_prep_activity() below
     # retires it once _sync_lfs_files() takes over with real progress.
-    vsdk_ota_rings.pulse_prep_activity()
+    _prep_checkpoint()
 
     try:
         try:
-            base_url = _resolve_base_url(base_url)
-            vsdk_ota_rings.pulse_prep_activity()
+            base_url = _resolve_base_url(base_url, feed=_prep_checkpoint)
+            _prep_checkpoint()
             manifest = _http_get_json(base_url + "/manifest")
-            vsdk_ota_rings.pulse_prep_activity()
+            _prep_checkpoint()
         except Exception as e:
             _send(("ota_error manifest_fetch_failed: %s\n" % e).encode())
             return
@@ -796,10 +974,18 @@ def run(base_url, send_fn):
         _send("ota_done ok\n")
         print("updater: OTA complete")
     finally:
+        # Feed on the way out too: this teardown runs after the last progress
+        # line, so without it the caller's watchdog is already counting down
+        # untouched by the time we get here.
+        if _feed_wdt:
+            _feed_wdt()
         # Only disconnect if we brought WiFi up — don't kill a pre-existing connection
-        # (e.g. desktop mode where comms.py already holds the link).
+        # (e.g. desktop mode where comms.py already holds the link) — and only
+        # if the caller isn't about to reconnect anyway (see disconnect_wifi).
         # Note: if _update_partitions flashed micropython and called machine.reset(),
         # we never reach here — that's fine, the reboot drops WiFi anyway.
-        if _newly_connected:
+        if _newly_connected and disconnect_wifi:
             _wifi_disconnect()
         vsdk_ota_rings.clear()
+        if _feed_wdt:
+            _feed_wdt()

--- a/apps/micropython/vsdk_recovery.py
+++ b/apps/micropython/vsdk_recovery.py
@@ -117,7 +117,13 @@ def _boot_into_micropython_if_ready():
 
 def _attempt(wdt):
     handle, outcome = _make_progress_handler(wdt)
-    updater.run(_OTA_URL, handle)
+    # The handler above only feeds the watchdog when a progress line actually
+    # arrives, and updater.run()'s prep phase (WiFi connect, address
+    # resolution, manifest fetch, .tmp scan) deliberately sends none -- pass
+    # the feeder in directly so that stretch stays covered too. Without it a
+    # base station that is slow, unreachable or simply switched off rebooted
+    # the board every 30s instead of failing into the backoff retry below.
+    updater.run(_OTA_URL, handle, feed_fn=lambda: _feed(wdt), disconnect_wifi=False)
     # updater.run() calls machine.reset() itself on a successful micropython
     # write; reaching here means either nothing needed a firmware write, or
     # something failed before that point.

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -153,7 +153,7 @@ class RecoveryTests(unittest.TestCase):
         import updater
 
         recovery._BOOT_GRACE_MS = 0  # skip the real boot grace period in tests
-        def _boom(url, send_fn):
+        def _boom(url, send_fn, **kwargs):
             raise RuntimeError("network stack exploded")
         original_run = updater.run
         updater.run = _boom

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -14,6 +14,32 @@ class _FakeReset(Exception):
     """Raised by the fake machine.reset() so tests can observe it fired."""
 
 
+def _fake_utime(clock=None):
+    """A `utime` stand-in whose clock only moves when a test moves it, so a
+    deadline loop under test runs its full iteration count rather than
+    however many happen to fit in real elapsed time."""
+    ticks = clock if clock is not None else [0]
+
+    class FakeUtime:
+        @staticmethod
+        def ticks_ms():
+            return ticks[0]
+
+        @staticmethod
+        def ticks_add(a, delta):
+            return a + delta
+
+        @staticmethod
+        def ticks_diff(a, b):
+            return a - b
+
+        @staticmethod
+        def sleep_ms(ms):
+            ticks[0] += ms
+
+    return FakeUtime
+
+
 def _install_fakes(running_label, nvs_blobs=None, find_results=None):
     """Install minimal esp32/machine stand-ins for updater.py's tier-3 tests.
 
@@ -427,7 +453,7 @@ class ResolveBaseUrlTests(unittest.TestCase):
                 "http://192.168.1.5:5653",
             )
 
-    def test_resolves_hostname_to_ip_once(self):
+    def test_resolves_ordinary_hostname_through_getaddrinfo(self):
         import updater
         calls = []
 
@@ -436,9 +462,122 @@ class ResolveBaseUrlTests(unittest.TestCase):
             return [(0, 0, 0, "", ("192.168.1.42", port))]
 
         with unittest.mock.patch.object(updater.socket, "getaddrinfo", fake_getaddrinfo):
-            resolved = updater._resolve_base_url("http://ventilastation-base.local:5653")
+            resolved = updater._resolve_base_url("http://base.example.com:5653")
         self.assertEqual(resolved, "http://192.168.1.42:5653")
-        self.assertEqual(calls, [("ventilastation-base.local", 5653)])
+        self.assertEqual(calls, [("base.example.com", 5653)])
+
+    def test_dot_local_goes_through_mdns_not_getaddrinfo(self):
+        """The .local path must not reach socket.getaddrinfo(): on hardware
+        that call never returns while the GPU task runs (see _mdns_resolve)."""
+        import updater
+
+        def _unexpected(host, *a):
+            raise AssertionError("getaddrinfo called for a .local name: %r" % host)
+
+        with unittest.mock.patch.object(updater, "_mdns_resolve", lambda h, f=None: "192.168.1.42"):
+            with unittest.mock.patch.object(updater.socket, "getaddrinfo", _unexpected):
+                resolved = updater._resolve_base_url("http://ventilastation-base.local:5653")
+        self.assertEqual(resolved, "http://192.168.1.42:5653")
+
+    def test_raises_when_mdns_finds_nothing(self):
+        """A base station that is off/unreachable has to surface as an error
+        the caller can retry after, not as a silent hang."""
+        import updater
+
+        with unittest.mock.patch.object(updater, "_mdns_resolve", lambda h, f=None: None):
+            with self.assertRaises(OSError):
+                updater._resolve_base_url("http://ventilastation-base.local:5653")
+
+
+class MdnsResolveTests(unittest.TestCase):
+    """_mdns_resolve() asks for a unicast response and gives up on a timer,
+    rather than relying on socket.getaddrinfo()'s unbounded .local lookup."""
+
+    def setUp(self):
+        sys.modules.pop("updater", None)
+        sys.modules["utime"] = _fake_utime()
+
+    def tearDown(self):
+        sys.modules.pop("utime", None)
+
+    @staticmethod
+    def _response(name, ip, qname=None):
+        """Minimal mDNS answer: one question echoed back, one A record."""
+        def labels(n):
+            out = b""
+            for part in n.split("."):
+                out += bytes([len(part)]) + part.encode()
+            return out + b"\x00"
+
+        header = b"\x00\x00\x84\x00\x00\x01\x00\x01\x00\x00\x00\x00"
+        question = labels(qname or name) + b"\x00\x01\x00\x01"
+        answer = labels(name) + b"\x00\x01\x00\x01\x00\x00\x00\x78\x00\x04" + bytes(
+            int(o) for o in ip.split(".")
+        )
+        return header + question + answer
+
+    def _resolve_with(self, packets):
+        import updater
+        sent = []
+
+        class FakeSock:
+            def __init__(self, *a):
+                self._queue = list(packets)
+
+            def settimeout(self, t):
+                self.timeout = t
+
+            def sendto(self, data, addr):
+                sent.append((data, addr))
+
+            def recvfrom(self, n):
+                if not self._queue:
+                    raise OSError("timed out")
+                return self._queue.pop(0), ("192.168.1.102", 5353)
+
+            def close(self):
+                pass
+
+        with unittest.mock.patch.object(updater.socket, "socket", FakeSock):
+            with unittest.mock.patch.object(
+                updater.socket, "getaddrinfo",
+                lambda h, p: [(0, 0, 0, "", (h, p))],
+            ):
+                return updater._mdns_resolve("ventilastation-base.local"), sent
+
+    def test_returns_the_address_from_a_matching_a_record(self):
+        addr, sent = self._resolve_with([self._response("ventilastation-base.local", "192.168.1.102")])
+        self.assertEqual(addr, "192.168.1.102")
+
+    def test_query_asks_for_a_unicast_response(self):
+        """The QU bit is the whole point: it makes the answer arrive as an
+        ordinary datagram on our own port instead of on the multicast group,
+        which is the path that breaks while the GPU task runs."""
+        _addr, sent = self._resolve_with([self._response("ventilastation-base.local", "192.168.1.102")])
+        query = sent[0][0]
+        self.assertEqual(query[-4:], b"\x00\x01\x80\x01")  # QTYPE=A, QCLASS=IN|QU
+        self.assertEqual(sent[0][1], ("224.0.0.251", 5353))
+
+    def test_ignores_an_a_record_for_a_different_host(self):
+        """Responders bundle unrelated records into the same message; taking
+        the first A record would point the OTA session at another machine."""
+        addr, _sent = self._resolve_with([
+            self._response("someone-else.local", "10.0.0.9", qname="ventilastation-base.local"),
+        ])
+        self.assertIsNone(addr)
+
+    def test_gives_up_after_the_attempt_budget_instead_of_blocking(self):
+        addr, sent = self._resolve_with([])
+        self.assertIsNone(addr)
+        import updater
+        self.assertEqual(len(sent), updater._MDNS_ATTEMPTS)
+
+    def test_survives_a_malformed_packet_and_keeps_reading(self):
+        addr, _sent = self._resolve_with([
+            b"\x00\x00\x84\x00\x00\x01\x00\x01",  # truncated garbage
+            self._response("ventilastation-base.local", "192.168.1.102"),
+        ])
+        self.assertEqual(addr, "192.168.1.102")
 
 
 class UrlQuoteTests(unittest.TestCase):
@@ -831,6 +970,139 @@ class WifiConnectRetryTests(unittest.TestCase):
         )
 
         self.assertTrue(updater._wifi_connect())
+
+
+class PrepPhaseWatchdogTests(unittest.TestCase):
+    """Everything between "WiFi connecting" and the first file/partition
+    total has to keep the caller's watchdog fed.
+
+    This stretch sends no progress lines, and recovery's handler only feeds
+    on lines it receives -- so before run() took a feed_fn it fed nothing at
+    all here. On a board whose base station was unreachable that showed up as
+    a 30s reboot cycle (recovery's WDT timeout, to the millisecond) with the
+    log stopping right after "WiFi connected", never reaching the retry
+    backoff it was supposed to fall into.
+    """
+
+    def setUp(self):
+        sys.modules.pop("updater", None)
+        sys.modules["utime"] = _fake_utime()
+
+    def tearDown(self):
+        for name in ("updater", "utime", "network", "machine", "esp32"):
+            sys.modules.pop(name, None)
+
+    def _run_prep(self, wifi_attempts_before_connecting=1, resolve=None, sent=None,
+                  disconnect_wifi=True, disconnects=None):
+        _install_fakes(
+            running_label="factory",
+            nvs_blobs={"ssid": "myssid", "password": "mypass"},
+        )
+        network = types.ModuleType("network")
+        network.STA_IF = "STA_IF"
+        state = {"attempt": 0}
+
+        class FakeWLAN:
+            def __init__(self, mode):
+                pass
+
+            def active(self, value=None):
+                pass
+
+            def isconnected(self):
+                return state["attempt"] >= wifi_attempts_before_connecting
+
+            def connect(self, ssid, password):
+                state["attempt"] += 1
+
+            def disconnect(self):
+                if disconnects is not None:
+                    disconnects.append(True)
+
+            def ifconfig(self):
+                return ("1.2.3.4",)
+
+        network.WLAN = FakeWLAN
+        sys.modules["network"] = network
+
+        import updater
+        feeds = []
+        updater.vsdk_ota_rings = types.SimpleNamespace(
+            clear=lambda: None,
+            show_wifi_problem=lambda: None,
+            show_wifi_connecting=lambda: None,
+            hide_wifi=lambda: None,
+            pulse_prep_activity=lambda: None,
+            hide_prep_activity=lambda: None,
+        )
+
+        def _resolve(url, feed=None):
+            if resolve is not None:
+                return resolve(url, feed)
+            return url
+
+        with unittest.mock.patch.object(updater, "_resolve_base_url", _resolve), \
+                unittest.mock.patch.object(
+                    updater, "_http_get_json",
+                    lambda url: (_ for _ in ()).throw(OSError("base station is off"))):
+            updater.run("http://ventilastation-base.local:5653",
+                        lambda line: sent.append(line) if sent is not None else None,
+                        feed_fn=lambda: feeds.append(True),
+                        disconnect_wifi=disconnect_wifi)
+        return feeds
+
+    def test_feeds_while_wifi_retries(self):
+        # Each attempt is ~10s of waiting; three of them already outlast a
+        # 30s watchdog, which is exactly why the red "wifi problem" ring
+        # (attempt 3 onward) could never actually be reached on hardware.
+        feeds = self._run_prep(wifi_attempts_before_connecting=4)
+        self.assertGreater(len(feeds), 10)
+
+    def test_feeds_while_resolving_the_base_station(self):
+        """The lookup itself gets the feeder, so all three mDNS attempts
+        against an absent base station stay inside the watchdog window."""
+        seen = []
+
+        def resolve(url, feed=None):
+            for _ in range(3):
+                feed()
+                seen.append(True)
+            return url
+
+        self._run_prep(resolve=resolve)
+        self.assertEqual(len(seen), 3)
+
+    def test_unreachable_base_station_reports_an_error_rather_than_hanging(self):
+        # _http_get_json above always raises: run() must come back with
+        # ota_error so recovery can back off and retry, not sit there.
+        sent = []
+        feeds = self._run_prep(sent=sent)
+        self.assertTrue(feeds)
+        joined = b"".join(
+            line if isinstance(line, bytes) else line.encode() for line in sent
+        )
+        self.assertIn(b"ota_error manifest_fetch_failed", joined)
+
+    def test_recovery_keeps_wifi_up_between_retries(self):
+        """The teardown runs after the last progress line, so it is the one
+        stretch a feed can't cover -- and on hardware it was where an attempt
+        that had already failed cleanly went on to trip the watchdog anyway.
+        Recovery reconnects seconds later regardless, so it skips it."""
+        disconnects = []
+        self._run_prep(disconnect_wifi=False, disconnects=disconnects)
+        self.assertEqual(disconnects, [])
+
+    def test_other_callers_still_tear_the_link_down(self):
+        # The normal OTA boot path must not leave WiFi on for the launcher.
+        disconnects = []
+        self._run_prep(disconnect_wifi=True, disconnects=disconnects)
+        self.assertEqual(disconnects, [True])
+
+    def test_feeds_after_the_teardown(self):
+        """A feed on the way out, so the caller's own loop doesn't inherit a
+        watchdog that has already been counting down since the last stage."""
+        feeds = self._run_prep(disconnect_wifi=False)
+        self.assertGreaterEqual(len(feeds), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A freshly flashed board sat in a 30s reboot cycle: the log stopped right after "updater: WiFi connected", never reaching "updater: resolved", and the watchdog fired at exactly last_feed + 30000ms every time.

Two independent defects combined into that loop.

1. socket.getaddrinfo() on a .local name never returns while the POV display's GPU task is running -- which in recovery it always is, drawing the progress rings. Measured on a rotor board, same session and network, minutes apart: display off, ventilastation-base.local resolved in 0.40-0.53s three times running; display on, the identical call never came back (one REPL session was still blocked after ten minutes). Plain unicast DNS (10ms) and TCP to the base station by IP (0.48s, HTTP 200) both stayed fine throughout, so it is the multicast path specifically -- consistent with coreTask() being a while(true) loop that never yields, pinned at priority 10, and with director.py's existing note that the normal OTA path reboots so the transfer runs before that task starts.

   Resolve .local names with our own mDNS query instead, asking for a unicast response (the QU bit): the answer then arrives as an ordinary datagram on our own ephemeral port rather than on the multicast group, so nothing depends on the receive path that breaks. A socket timeout bounds it, turning "base station is off" into an ota_error the caller can retry after rather than a hang. Answers are matched by record name, since a responder may bundle unrelated A records into the same message.

2. Recovery's watchdog is fed only as a side effect of progress lines arriving, and two stretches deliberately send none:

   - the prep phase (WiFi connect, address resolution, manifest fetch, .tmp scan), which also made _wifi_connect()'s indefinite retry unreachable in practice -- its red "wifi problem" ring needs three attempts (~24-36s), so the reboot always won first;
   - run()'s teardown, which runs after the last progress line. Observed on hardware even once the lookup was bounded: ota_error at t+16s, then a WDT reset at t+46s with nothing in between.

   run() now takes a feed_fn, and _prep_checkpoint() bundles the ring pulse
   and the watchdog feed into one call so the two can't drift apart again
   (the pulses were already at the right checkpoints; only the feed was
   missing). Recovery also passes disconnect_wifi=False: it reconnects
   seconds later anyway, and a reboot drops the link regardless.

Verified on hardware. Base station present: resolved in 400ms with the display running, full OTA including a 55s uninterrupted partition write, rebooted into the launcher. Base station off: no reboots in 170s, clean ota_error every ~6s, retries following _BACKOFF_SCHEDULE_MS (5/10/20/30s), WiFi held across retries, and a full self-healing OTA the moment the server came back.

Also fixes a test_recovery stub that was passing for the wrong reason: its fake updater.run rejected the new kwarg, so a TypeError was standing in for the fatal error under test.