### PR TITLE
Make the OTA shortcut work in headless console mode

### DIFF
--- a/emulator/consoleengine.py
+++ b/emulator/consoleengine.py
@@ -34,7 +34,9 @@ import pyglet_evdev_fix
 from audio import sound_init, sound_process_queue
 from emu_audio import emu_audio
 from evdev_keys import MultiKeyState
-from inputs_common import keyboard_state, keyboard_v2_state, pack_controllers
+from inputs_common import (
+    keyboard_state, keyboard_v2_state, ota_shortcut_held, pack_controllers,
+)
 from pyglet.window import key
 
 pyglet_evdev_fix.apply()
@@ -63,6 +65,7 @@ class ConsoleEngine:
 
         self.last_input_sent = (0, 0, 0)
         self.last_exit_pressed = False
+        self.last_ota_pressed = False
 
     def _refresh_controllers(self):
         connected = list(self.controller_manager.get_controllers())[:2]
@@ -96,6 +99,13 @@ class ConsoleEngine:
         if exit_pressed and not self.last_exit_pressed:
             comms.send_command("exit")
         self.last_exit_pressed = exit_pressed
+        # The windowed backends get this from on_key_press; with no window
+        # there is no such event, so the chord is edge-detected off the same
+        # polled state _encode_input() just refreshed.
+        ota_pressed = ota_shortcut_held(self.keys)
+        if ota_pressed and not self.last_ota_pressed:
+            comms.trigger_ota()
+        self.last_ota_pressed = ota_pressed
         sound_process_queue()
         emu_audio.process()  # drive emulator-audio player lifecycle (main thread)
 

--- a/emulator/evdev_keys.py
+++ b/emulator/evdev_keys.py
@@ -36,6 +36,7 @@ except ImportError:
 from pyglet.window import key as pygkey
 
 _EVDEV_TO_PYGLET = {}
+_DETECTION_KEYS = frozenset()
 if evdev is not None:
     _EVDEV_TO_PYGLET = {
         ecodes.KEY_LEFT: pygkey.LEFT,
@@ -64,6 +65,20 @@ if evdev is not None:
         ecodes.KEY_END: pygkey.END,
         ecodes.KEY_ESC: pygkey.ESCAPE,
     }
+    # Auto-detect below scores a candidate device on the gameplay keys only.
+    _DETECTION_KEYS = frozenset(_EVDEV_TO_PYGLET)
+    # The OTA shortcut chord (Ctrl-U, see inputs_common.ota_shortcut_held).
+    # Translated like any other key, but deliberately not part of
+    # _DETECTION_KEYS: modifiers are common on HID devices that are not the
+    # arcade panel's encoder, and letting them count toward the threshold
+    # would loosen what qualifies as a keyboard.
+    _EVDEV_TO_PYGLET.update({
+        ecodes.KEY_U: pygkey.U,
+        ecodes.KEY_LEFTCTRL: pygkey.LCTRL,
+        ecodes.KEY_RIGHTCTRL: pygkey.RCTRL,
+        ecodes.KEY_LEFTMETA: pygkey.LCOMMAND,
+        ecodes.KEY_RIGHTMETA: pygkey.RCOMMAND,
+    })
 
 _UP, _DOWN, _REPEAT = 0, 1, 2
 
@@ -98,7 +113,7 @@ def _is_joystick_like(device):
 
 def _looks_like_keyboard(device):
     keys = set(device.capabilities().get(ecodes.EV_KEY, []))
-    if len(keys & set(_EVDEV_TO_PYGLET)) < _MIN_MATCHING_KEYS:
+    if len(keys & _DETECTION_KEYS) < _MIN_MATCHING_KEYS:
         return False
     return not _is_joystick_like(device)
 

--- a/emulator/inputs_common.py
+++ b/emulator/inputs_common.py
@@ -90,6 +90,25 @@ def ota_shortcut_pressed(symbol, modifiers):
     return symbol == key.U and bool(modifiers & (key.MOD_CTRL | key.MOD_COMMAND))
 
 
+# Both symbol spellings of each modifier: which one a held key reads as
+# depends on the pyglet backend, and console mode gets its own from
+# evdev_keys' translation table rather than from pyglet at all.
+OTA_MODIFIER_KEYS = (
+    key.LCTRL, key.RCTRL, key.LCOMMAND, key.RCOMMAND, key.LMETA, key.RMETA,
+)
+
+
+def ota_shortcut_held(keys):
+    """Same chord as ota_shortcut_pressed(), read from polled key state.
+
+    Console mode never creates a window (see consoleengine.py), so nothing
+    delivers on_key_press and there is no `modifiers` mask to test -- it polls
+    evdev state instead. Keeping both forms here means the shortcut has one
+    definition rather than drifting between the windowed and headless engines.
+    """
+    return bool(keys[key.U]) and any(bool(keys[symbol]) for symbol in OTA_MODIFIER_KEYS)
+
+
 def pack_directions(left, right, up, down):
     return (bool(left) << 0 | bool(right) << 1 |
             bool(up) << 2 | bool(down) << 3)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -77,6 +77,7 @@ CPYTHON_TESTS = [
     "tests/test_native_exit_transition.py",
     "tests/test_input_protocol_v2.py",
     "tests/test_emulator_inputs_v2.py",
+    "tests/test_console_ota_shortcut.py",
     "tests/test_emulator_ota.py",
     "tests/test_workbench_telemetry.py",
     "tests/test_host_protocol.py",

--- a/tests/test_console_ota_shortcut.py
+++ b/tests/test_console_ota_shortcut.py
@@ -1,0 +1,180 @@
+"""Headless (--no-display) OTA shortcut.
+
+Console mode never creates a window, so the Ctrl-U handler that pyglet1x and
+pyglet2x hang off ``on_key_press`` never runs there -- consoleengine.py has to
+edge-detect the chord from polled evdev state instead. These checks cover that
+path end to end without needing pyglet, evdev, or an audio stack.
+"""
+
+import sys
+import types
+
+
+fake_key = types.SimpleNamespace(
+    LEFT=1, RIGHT=2, UP=3, DOWN=4, A=5, D=6, W=7, S=8, SPACE=9, O=10, P=11,
+    H=12, J=13, K=14, L=15, Z=16, X=17, C=18, V=19, Y=20,
+    PAGEUP=21, PAGEDOWN=22, HOME=23, END=24, ESCAPE=25,
+    U=26, LCTRL=27, RCTRL=28, LCOMMAND=29, RCOMMAND=30, LMETA=31, RMETA=32,
+    MOD_CTRL=0x100, MOD_COMMAND=0x200,
+)
+
+_KEY_NAMES = [
+    "KEY_LEFT", "KEY_RIGHT", "KEY_UP", "KEY_DOWN", "KEY_A", "KEY_D", "KEY_W",
+    "KEY_S", "KEY_SPACE", "KEY_O", "KEY_P", "KEY_H", "KEY_J", "KEY_K", "KEY_L",
+    "KEY_Z", "KEY_X", "KEY_C", "KEY_V", "KEY_Y", "KEY_PAGEUP", "KEY_PAGEDOWN",
+    "KEY_HOME", "KEY_END", "KEY_ESC",
+    "KEY_U", "KEY_LEFTCTRL", "KEY_RIGHTCTRL", "KEY_LEFTMETA", "KEY_RIGHTMETA",
+]
+# Real evdev keeps KEY_* below BTN_JOYSTICK (0x120); preserve that ordering so
+# evdev_keys._is_joystick_like() keeps its real meaning under the stub.
+fake_ecodes = types.SimpleNamespace(
+    EV_KEY=1, EV_ABS=3, BTN_JOYSTICK=0x120,
+    **{name: index + 1 for index, name in enumerate(_KEY_NAMES)}
+)
+
+EV_KEY, _UP, _DOWN = fake_ecodes.EV_KEY, 0, 1
+
+
+def _install_stubs():
+    fake_pyglet = types.ModuleType("pyglet")
+    fake_pyglet.options = {}
+    fake_window = types.ModuleType("pyglet.window")
+    fake_window.key = fake_key
+    fake_pyglet.window = fake_window
+
+    fake_evdev = types.ModuleType("evdev")
+    fake_evdev.ecodes = fake_ecodes
+    fake_evdev.list_devices = lambda: []
+    fake_evdev.InputDevice = lambda path: None
+    fake_ecodes_module = types.ModuleType("evdev.ecodes")
+
+    fake_fix = types.ModuleType("pyglet_evdev_fix")
+    fake_fix.apply = lambda: None
+
+    fake_audio = types.ModuleType("audio")
+    fake_audio.sound_init = lambda: None
+    fake_audio.sound_process_queue = lambda: None
+
+    fake_emu_audio = types.ModuleType("emu_audio")
+    fake_emu_audio.emu_audio = types.SimpleNamespace(process=lambda: None)
+
+    for name, module in (
+        ("pyglet", fake_pyglet), ("pyglet.window", fake_window),
+        ("evdev", fake_evdev), ("evdev.ecodes", fake_ecodes_module),
+        ("pyglet_evdev_fix", fake_fix),
+        ("audio", fake_audio), ("emu_audio", fake_emu_audio),
+    ):
+        sys.modules.setdefault(name, module)
+    sys.path.insert(0, "emulator")
+
+
+_install_stubs()
+
+from evdev_keys import _DETECTION_KEYS, _EVDEV_TO_PYGLET, MultiKeyState  # noqa: E402
+from inputs_common import ota_shortcut_held  # noqa: E402
+
+
+class FakeEvent:
+    def __init__(self, code, value):
+        self.type, self.code, self.value = EV_KEY, code, value
+
+
+class FakeDevice:
+    name = "fake arcade encoder"
+
+    def __init__(self):
+        self.pending = []
+
+    def read(self):
+        events, self.pending = self.pending, []
+        return events
+
+
+def _keyboard_with(device):
+    keys = MultiKeyState()
+    keys._devices["/dev/input/fake"] = (device, set())
+    return keys
+
+
+def test_evdev_table_translates_the_ota_chord():
+    assert _EVDEV_TO_PYGLET[fake_ecodes.KEY_U] == fake_key.U
+    assert _EVDEV_TO_PYGLET[fake_ecodes.KEY_LEFTCTRL] == fake_key.LCTRL
+    assert _EVDEV_TO_PYGLET[fake_ecodes.KEY_RIGHTCTRL] == fake_key.RCTRL
+
+
+def test_ota_chord_does_not_loosen_keyboard_detection():
+    # Modifiers show up on plenty of HID devices that are not the arcade
+    # panel's encoder, so they must not count toward _MIN_MATCHING_KEYS.
+    for code in (fake_ecodes.KEY_U, fake_ecodes.KEY_LEFTCTRL,
+                 fake_ecodes.KEY_RIGHTCTRL, fake_ecodes.KEY_LEFTMETA,
+                 fake_ecodes.KEY_RIGHTMETA):
+        assert code not in _DETECTION_KEYS
+    assert fake_ecodes.KEY_LEFT in _DETECTION_KEYS
+    assert fake_ecodes.KEY_ESC in _DETECTION_KEYS
+
+
+def test_held_ctrl_u_reaches_the_shortcut_through_evdev():
+    device = FakeDevice()
+    keys = _keyboard_with(device)
+
+    device.pending = [FakeEvent(fake_ecodes.KEY_LEFTCTRL, _DOWN)]
+    keys.poll()
+    assert not ota_shortcut_held(keys)
+
+    device.pending = [FakeEvent(fake_ecodes.KEY_U, _DOWN)]
+    keys.poll()
+    assert ota_shortcut_held(keys)
+
+    device.pending = [FakeEvent(fake_ecodes.KEY_U, _UP)]
+    keys.poll()
+    assert not ota_shortcut_held(keys)
+
+
+def test_console_tick_triggers_ota_once_per_press():
+    from consoleengine import ConsoleEngine
+
+    triggered = []
+    fake_comms = types.ModuleType("comms")
+    fake_comms.trigger_ota = lambda: triggered.append(1)
+    fake_comms.send_joystick = lambda *args: None
+    fake_comms.send_command = lambda *args: None
+    sys.modules["comms"] = fake_comms
+
+    device = FakeDevice()
+    engine = object.__new__(ConsoleEngine)  # __init__ opens audio and controllers
+    engine.keys = _keyboard_with(device)
+    engine.controllers = []
+    engine.last_input_sent = (0, 0, 0)
+    engine.last_exit_pressed = False
+    engine.last_ota_pressed = False
+
+    engine._tick(0)
+    assert triggered == []
+
+    device.pending = [FakeEvent(fake_ecodes.KEY_LEFTCTRL, _DOWN),
+                      FakeEvent(fake_ecodes.KEY_U, _DOWN)]
+    engine._tick(0)
+    assert triggered == [1]
+
+    # Held across further ticks: one OTA per press, not one per frame.
+    engine._tick(0)
+    engine._tick(0)
+    assert triggered == [1]
+
+    device.pending = [FakeEvent(fake_ecodes.KEY_U, _UP)]
+    engine._tick(0)
+    device.pending = [FakeEvent(fake_ecodes.KEY_U, _DOWN)]
+    engine._tick(0)
+    assert triggered == [1, 1]
+
+
+def main():
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+        print("ok", test.__name__)
+    print("console OTA shortcut: %d checks passed" % len(tests))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_emulator_inputs_v2.py
+++ b/tests/test_emulator_inputs_v2.py
@@ -11,6 +11,8 @@ fake_window.key = types.SimpleNamespace(
     A="A", D="D", W="W", S="S", SPACE="SPACE", O="O", P="P", U="U", Y="Y",
     H="H", J="J", K="K", L="L", Z="Z", X="X", C="C", V="V",
     PAGEUP="PAGEUP", PAGEDOWN="PAGEDOWN", HOME="HOME", END="END",
+    LCTRL="LCTRL", RCTRL="RCTRL", LCOMMAND="LCOMMAND", RCOMMAND="RCOMMAND",
+    LMETA="LMETA", RMETA="RMETA",
     MOD_CTRL=0x100, MOD_COMMAND=0x200,
 )
 fake_pyglet.window = fake_window
@@ -27,6 +29,7 @@ from inputs_common import (  # noqa: E402
     EXTRA_JOY2_Y,
     keyboard_state,
     keyboard_v2_state,
+    ota_shortcut_held,
     ota_shortcut_pressed,
     pack_controllers,
 )
@@ -122,6 +125,22 @@ def test_ota_shortcut_requires_ctrl_or_command():
     assert ota_shortcut_pressed("U", 0x200)
     assert not ota_shortcut_pressed("U", 0)
     assert not ota_shortcut_pressed("Y", 0x100)
+
+
+def test_ota_shortcut_held_reads_polled_state():
+    # Console mode has no key-press events, so the same chord has to be
+    # recognizable from held keys alone (see consoleengine.py).
+    held = lambda *pressed: {symbol: symbol in pressed for symbol in (
+        "U", "Y", "LCTRL", "RCTRL", "LCOMMAND", "RCOMMAND", "LMETA", "RMETA")}
+
+    assert ota_shortcut_held(held("U", "LCTRL"))
+    assert ota_shortcut_held(held("U", "RCTRL"))
+    assert ota_shortcut_held(held("U", "LCOMMAND"))
+    assert ota_shortcut_held(held("U", "RMETA"))
+    assert not ota_shortcut_held(held("U"))
+    assert not ota_shortcut_held(held("LCTRL"))
+    assert not ota_shortcut_held(held("Y", "LCTRL"))
+    assert not ota_shortcut_held(held())
 
 
 def main():


### PR DESCRIPTION
Ctrl-U triggers an OTA in the windowed backends because pyglet1x/inputs.py and pyglet2x/inputs.py check it from `on_key_press`. Console mode (--no-display, the production Base) never creates a window, so nothing dispatches key events there and consoleengine.py never looked at the shortcut at all.

Two things were missing. consoleengine polls evdev state rather than receiving events, so it needs a polled form of the chord -- ota_shortcut_held(), kept next to ota_shortcut_pressed() so the shortcut has one definition. And the evdev translation table had neither KEY_U nor any modifier, so the chord could not be represented even in principle.

Edge-detect it in _tick() the same way exit_pressed already is, so holding the keys triggers one OTA rather than one per frame.

The new keys are deliberately excluded from device auto-detection, which now scores candidates on a separate _DETECTION_KEYS set: modifiers are common on HID devices that are not the arcade panel's encoder, and letting them count toward _MIN_MATCHING_KEYS would loosen what qualifies as a keyboard.