### PR TITLE
Fix an SPI crash entering Ventilagon: drain the pending column write …

### DIFF
--- a/hardware/rotor/modules/povdisplay/povdisplay.c
+++ b/hardware/rotor/modules/povdisplay/povdisplay.c
@@ -493,6 +493,18 @@ void coreTask( void * pvParameters ){
     while(true){
         hall_filter_drain();
         if (ventilagon_active) {
+            // ventilagon_active is set from MicroPython (ventilagon_enter(),
+            // a different task) and can flip true right between two loop
+            // iterations. gpu_serve() below always leaves an SPI DMA
+            // in flight (spi_write_HSPI(), meant to be drained by *its own*
+            // next call's spiWaitComplete()) -- if the switch lands right
+            // then, that write never gets drained, and ventilagon's own
+            // state->loop() (display.c, state_win_credits.c) calls
+            // spi_write_HSPI() again on top of it: "Cannot send polling
+            // transaction while the previous polling transaction is not
+            // terminated." spiWaitComplete() is a no-op when nothing is
+            // pending, so this costs nothing on every other iteration.
+            spiWaitComplete();
             ventilagon_loop();
         } else {
             gpu_serve();


### PR DESCRIPTION
…first

coreTask() switches between the normal renderer (gpu_serve()) and Ventilagon's own (ventilagon_loop()) on a flag set from MicroPython, a different task. gpu_serve() always leaves an SPI DMA in flight -- meant to be drained by its own next call -- so if the switch lands right after one such write, that transaction never gets drained, and Ventilagon's own rendering (display.c, state_win_credits.c) starts a new one on top of it: "Cannot send polling transaction while the previous polling transaction is not terminated."

Ventilagon's code hasn't changed; gpu_serve() started overlapping its SPI writes with projection for a real performance win (see "Fix POV framebuffer glitch: make MicroPython path single-task", 2026-07-23), which is what exposed this -- the bus is no longer guaranteed idle by the time Ventilagon's renderer takes over.

Verified on hardware: 60 back-to-back enter()/exit() cycles (the exact transition window, bypassing menu navigation) all passed cleanly with this fix in place. Did not reproduce the crash against the pre-fix code as a negative control -- skipped at the user's request.